### PR TITLE
fix: remove oh-my-codex before install

### DIFF
--- a/bin/lazycodex-ai.js
+++ b/bin/lazycodex-ai.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process"
-import { basename } from "node:path"
+import { existsSync, rmSync } from "node:fs"
+import { homedir } from "node:os"
+import { basename, delimiter, join } from "node:path"
 
 const args = process.argv.slice(2)
 const dryRun = args[0] === "--dry-run"
@@ -15,23 +17,36 @@ const cleanupCommands = [
   ["omx", ["uninstall", "--purge"]],
   ["npm", ["uninstall", "-g", "oh-my-codex"]],
 ]
+const residuePaths = [
+  join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "plugins", "cache", "oh-my-codex-local"),
+  join(process.cwd(), ".omx"),
+]
 
 function findCommand(command) {
-  const result = spawnSync("which", [command], {
-    encoding: "utf8",
-  })
+  const extensions = process.platform === "win32" ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";") : [""]
+  const names = extensions.map((extension) => `${command}${extension.toLowerCase() === command.toLowerCase().slice(-extension.length) ? "" : extension}`)
 
-  if (result.status !== 0) {
-    return ""
+  for (const directory of (process.env.PATH ?? "").split(delimiter)) {
+    for (const name of names) {
+      const path = join(directory, name)
+
+      if (existsSync(path)) {
+        return path
+      }
+    }
   }
 
-  return result.stdout.trim()
+  return ""
 }
 
 function runCommand(command, args) {
   return spawnSync(command, args, {
     stdio: "inherit",
   })
+}
+
+function removePath(path) {
+  rmSync(path, { recursive: true, force: true })
 }
 
 if (dryRun) {
@@ -62,21 +77,15 @@ if (isInstall) {
     }
   }
 
+  for (const path of residuePaths) {
+    removePath(path)
+  }
+
   const remainingOmxPath = findCommand("omx")
 
   if (remainingOmxPath) {
     if (basename(remainingOmxPath) === "omx") {
-      const remove = runCommand("rm", [remainingOmxPath])
-
-      if (remove.error) {
-        console.error(`oh-my-codex cleanup failed: ${remove.error.message}`)
-        process.exit(1)
-      }
-
-      if ((remove.status ?? 1) !== 0) {
-        console.error(`oh-my-codex cleanup failed: rm ${remainingOmxPath}`)
-        process.exit(1)
-      }
+      removePath(remainingOmxPath)
     }
   }
 

--- a/bin/lazycodex-ai.js
+++ b/bin/lazycodex-ai.js
@@ -1,23 +1,94 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process"
+import { basename } from "node:path"
 
 const args = process.argv.slice(2)
 const dryRun = args[0] === "--dry-run"
 const forwardedArgs = dryRun ? args.slice(1) : args
+const isInstall = forwardedArgs[0] === "install"
 const commandArgs =
-  forwardedArgs[0] === "install"
+  isInstall
     ? ["--package", "oh-my-openagent", "omo", "install", "--platform=codex", ...forwardedArgs.slice(1)]
     : ["--package", "oh-my-openagent", "omo", ...forwardedArgs]
+const cleanupCommands = [
+  ["omx", ["uninstall", "--purge"]],
+  ["npm", ["uninstall", "-g", "oh-my-codex"]],
+]
+
+function findCommand(command) {
+  const result = spawnSync("which", [command], {
+    encoding: "utf8",
+  })
+
+  if (result.status !== 0) {
+    return ""
+  }
+
+  return result.stdout.trim()
+}
+
+function runCommand(command, args) {
+  return spawnSync(command, args, {
+    stdio: "inherit",
+  })
+}
 
 if (dryRun) {
+  if (isInstall) {
+    for (const [command, args] of cleanupCommands) {
+      console.log([command, ...args].join(" "))
+    }
+  }
+
   console.log(["bunx", ...commandArgs].join(" "))
   process.exit(0)
 }
 
-const result = spawnSync("bunx", commandArgs, {
-  stdio: "inherit",
-})
+if (isInstall) {
+  const commands = findCommand("omx") ? cleanupCommands : cleanupCommands.slice(1)
+
+  for (const [command, args] of commands) {
+    const cleanup = runCommand(command, args)
+
+    if (cleanup.error) {
+      console.error(`oh-my-codex cleanup failed: ${cleanup.error.message}`)
+      process.exit(1)
+    }
+
+    if ((cleanup.status ?? 1) !== 0) {
+      console.error(`oh-my-codex cleanup failed: ${command} ${args.join(" ")}`)
+      process.exit(1)
+    }
+  }
+
+  const remainingOmxPath = findCommand("omx")
+
+  if (remainingOmxPath) {
+    if (basename(remainingOmxPath) === "omx") {
+      const remove = runCommand("rm", [remainingOmxPath])
+
+      if (remove.error) {
+        console.error(`oh-my-codex cleanup failed: ${remove.error.message}`)
+        process.exit(1)
+      }
+
+      if ((remove.status ?? 1) !== 0) {
+        console.error(`oh-my-codex cleanup failed: rm ${remainingOmxPath}`)
+        process.exit(1)
+      }
+    }
+  }
+
+  const verifiedOmxPath = findCommand("omx")
+
+  if (verifiedOmxPath) {
+    console.error(`oh-my-codex cleanup failed: omx is still installed at ${verifiedOmxPath}`)
+    process.exit(1)
+  }
+}
+
+const result = runCommand("bunx", commandArgs)
 
 if (result.error) {
   console.error(result.error.message)

--- a/test/lazycodex-ai-bin.test.mjs
+++ b/test/lazycodex-ai-bin.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { basename, join } from "node:path"
 import { tmpdir } from "node:os"
 import { spawnSync } from "node:child_process"
@@ -11,7 +11,6 @@ const binPath = join(root, "bin", "lazycodex-ai.js")
 
 function withFakeBin(files, run) {
   const tempDir = mkdtempSync(join(tmpdir(), "lazycodex-ai-test-"))
-  const commandStatePath = join(tempDir, "omx-paths")
 
   try {
     for (const [name, contents] of Object.entries(files)) {
@@ -23,7 +22,6 @@ function withFakeBin(files, run) {
       tempDir,
       PATH: tempDir,
       LAZYCODEX_TEST_LOG: join(tempDir, "commands.log"),
-      LAZYCODEX_COMMAND_STATE: commandStatePath,
     })
   } finally {
     rmSync(tempDir, { recursive: true, force: true })
@@ -44,32 +42,6 @@ const fakeNpm = `#!/bin/sh
 printf 'npm %s\n' "$*" >> "$LAZYCODEX_TEST_LOG"
 exit 0
 `
-
-const fakeRm = `#!/bin/sh
-printf 'rm %s\n' "$*" >> "$LAZYCODEX_TEST_LOG"
-/bin/rm "$@"
-`
-
-const fakeWhich = `#!/bin/sh
-if [ "$1" != "omx" ] || [ ! -f "$LAZYCODEX_COMMAND_STATE" ]; then
-  exit 1
-fi
-
-first=$(/usr/bin/sed -n '1p' "$LAZYCODEX_COMMAND_STATE")
-/usr/bin/sed '1d' "$LAZYCODEX_COMMAND_STATE" > "$LAZYCODEX_COMMAND_STATE.next"
-/bin/mv "$LAZYCODEX_COMMAND_STATE.next" "$LAZYCODEX_COMMAND_STATE"
-
-if [ -n "$first" ]; then
-  printf '%s\n' "$first"
-  exit 0
-fi
-
-exit 1
-`
-
-function setOmxLookups(env, paths) {
-  writeFileSync(env.LAZYCODEX_COMMAND_STATE, `${paths.join("\n")}\n`)
-}
 
 describe("lazycodex-ai npm package", () => {
   it("maps the package name and bin to lazycodex-ai", () => {
@@ -113,8 +85,7 @@ describe("lazycodex-ai npm package", () => {
     // given
     assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
 
-    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm, which: fakeWhich }, (env) => {
-      setOmxLookups(env, ["/tmp/omx", ""])
+    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm }, (env) => {
 
       // when
       const result = spawnSync(process.execPath, [binPath, "install"], {
@@ -140,8 +111,7 @@ describe("lazycodex-ai npm package", () => {
     // given
     assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
 
-    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm, which: fakeWhich }, (env) => {
-      setOmxLookups(env, ["/tmp/omx"])
+    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm }, (env) => {
 
       // when
       const result = spawnSync(process.execPath, [binPath, "doctor"], {
@@ -164,8 +134,7 @@ printf 'omx %s\n' "$*" >> "$LAZYCODEX_TEST_LOG"
 exit 42
 `
 
-    withFakeBin({ bunx: fakeBunx, omx: failingOmx, npm: fakeNpm, which: fakeWhich }, (env) => {
-      setOmxLookups(env, ["/tmp/omx"])
+    withFakeBin({ bunx: fakeBunx, omx: failingOmx, npm: fakeNpm }, (env) => {
 
       // when
       const result = spawnSync(process.execPath, [binPath, "install"], {
@@ -185,8 +154,7 @@ exit 42
     // given
     assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
 
-    withFakeBin({ bunx: fakeBunx, npm: fakeNpm, which: fakeWhich }, (env) => {
-      setOmxLookups(env, ["", ""])
+    withFakeBin({ bunx: fakeBunx, npm: fakeNpm }, (env) => {
 
       // when
       const result = spawnSync(process.execPath, [binPath, "install"], {
@@ -207,12 +175,11 @@ exit 42
     })
   })
 
-  it("aborts install when omx is still installed after cleanup", () => {
+  it("removes a leftover omx command before installing lazycodex", () => {
     // given
     assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
 
-    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm, which: fakeWhich }, (env) => {
-      setOmxLookups(env, ["/tmp/omx", "/tmp/stale-omx", "/tmp/stale-omx"])
+    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm }, (env) => {
 
       // when
       const result = spawnSync(process.execPath, [binPath, "install"], {
@@ -222,11 +189,10 @@ exit 42
       })
 
       // then
-      assert.equal(result.status, 1)
-      assert.match(result.stderr, /omx is still installed at \/tmp\/stale-omx/)
+      assert.equal(result.status, 0, result.stderr)
       assert.equal(
         readFileSync(env.LAZYCODEX_TEST_LOG, "utf8").trim(),
-        ["omx uninstall --purge", "npm uninstall -g oh-my-codex"].join("\n"),
+        ["omx uninstall --purge", "npm uninstall -g oh-my-codex", "bunx --package oh-my-openagent omo install --platform=codex"].join("\n"),
       )
     })
   })
@@ -235,9 +201,8 @@ exit 42
     // given
     assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
 
-    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm, which: fakeWhich, rm: fakeRm }, (env) => {
+    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm }, (env) => {
       const staleOmxPath = join(env.tempDir, "omx")
-      setOmxLookups(env, [staleOmxPath, staleOmxPath, ""])
 
       // when
       const result = spawnSync(process.execPath, [binPath, "install"], {
@@ -254,11 +219,44 @@ exit 42
         [
           "omx uninstall --purge",
           "npm uninstall -g oh-my-codex",
-          `rm ${staleOmxPath}`,
           "bunx --package oh-my-openagent omo install --platform=codex",
         ].join("\n"),
       )
       assert.equal(basename(staleOmxPath), "omx")
+    })
+  })
+
+  it("removes known oh-my-codex residue before installing lazycodex", () => {
+    // given
+    assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
+
+    withFakeBin({ bunx: fakeBunx, npm: fakeNpm }, (env) => {
+      const codexHome = join(env.tempDir, "codex-home")
+      const pluginCache = join(codexHome, "plugins", "cache", "oh-my-codex-local")
+      const projectOmx = join(env.tempDir, "project", ".omx")
+      mkdirSync(pluginCache, { recursive: true })
+      mkdirSync(projectOmx, { recursive: true })
+      writeFileSync(join(pluginCache, "marker"), "plugin cache")
+      writeFileSync(join(projectOmx, "marker"), "project state")
+
+      // when
+      const result = spawnSync(process.execPath, [binPath, "install"], {
+        cwd: join(env.tempDir, "project"),
+        encoding: "utf8",
+        env: { ...process.env, ...env, CODEX_HOME: codexHome },
+      })
+
+      // then
+      assert.equal(result.status, 0, result.stderr)
+      assert.equal(existsSync(pluginCache), false, "oh-my-codex plugin cache should be removed")
+      assert.equal(existsSync(projectOmx), false, "project .omx state should be removed")
+      assert.equal(
+        readFileSync(env.LAZYCODEX_TEST_LOG, "utf8").trim(),
+        [
+          "npm uninstall -g oh-my-codex",
+          "bunx --package oh-my-openagent omo install --platform=codex",
+        ].join("\n"),
+      )
     })
   })
 

--- a/test/lazycodex-ai-bin.test.mjs
+++ b/test/lazycodex-ai-bin.test.mjs
@@ -1,12 +1,75 @@
 import assert from "node:assert/strict"
-import { existsSync, readFileSync } from "node:fs"
-import { join } from "node:path"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { basename, join } from "node:path"
+import { tmpdir } from "node:os"
 import { spawnSync } from "node:child_process"
 import { describe, it } from "node:test"
 
 const root = new URL("..", import.meta.url).pathname
 const packageJsonPath = join(root, "package.json")
 const binPath = join(root, "bin", "lazycodex-ai.js")
+
+function withFakeBin(files, run) {
+  const tempDir = mkdtempSync(join(tmpdir(), "lazycodex-ai-test-"))
+  const commandStatePath = join(tempDir, "omx-paths")
+
+  try {
+    for (const [name, contents] of Object.entries(files)) {
+      const path = join(tempDir, name)
+      writeFileSync(path, contents, { mode: 0o755 })
+    }
+
+    return run({
+      tempDir,
+      PATH: tempDir,
+      LAZYCODEX_TEST_LOG: join(tempDir, "commands.log"),
+      LAZYCODEX_COMMAND_STATE: commandStatePath,
+    })
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+const fakeBunx = `#!/bin/sh
+printf 'bunx %s\n' "$*" >> "$LAZYCODEX_TEST_LOG"
+exit 0
+`
+
+const fakeOmx = `#!/bin/sh
+printf 'omx %s\n' "$*" >> "$LAZYCODEX_TEST_LOG"
+exit 0
+`
+
+const fakeNpm = `#!/bin/sh
+printf 'npm %s\n' "$*" >> "$LAZYCODEX_TEST_LOG"
+exit 0
+`
+
+const fakeRm = `#!/bin/sh
+printf 'rm %s\n' "$*" >> "$LAZYCODEX_TEST_LOG"
+/bin/rm "$@"
+`
+
+const fakeWhich = `#!/bin/sh
+if [ "$1" != "omx" ] || [ ! -f "$LAZYCODEX_COMMAND_STATE" ]; then
+  exit 1
+fi
+
+first=$(/usr/bin/sed -n '1p' "$LAZYCODEX_COMMAND_STATE")
+/usr/bin/sed '1d' "$LAZYCODEX_COMMAND_STATE" > "$LAZYCODEX_COMMAND_STATE.next"
+/bin/mv "$LAZYCODEX_COMMAND_STATE.next" "$LAZYCODEX_COMMAND_STATE"
+
+if [ -n "$first" ]; then
+  printf '%s\n' "$first"
+  exit 0
+fi
+
+exit 1
+`
+
+function setOmxLookups(env, paths) {
+  writeFileSync(env.LAZYCODEX_COMMAND_STATE, `${paths.join("\n")}\n`)
+}
 
 describe("lazycodex-ai npm package", () => {
   it("maps the package name and bin to lazycodex-ai", () => {
@@ -38,8 +101,165 @@ describe("lazycodex-ai npm package", () => {
     assert.equal(result.status, 0, result.stderr)
     assert.equal(
       result.stdout.trim(),
-      "bunx --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous",
+      [
+        "omx uninstall --purge",
+        "npm uninstall -g oh-my-codex",
+        "bunx --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous",
+      ].join("\n"),
     )
+  })
+
+  it("removes oh-my-codex before installing lazycodex", () => {
+    // given
+    assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
+
+    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm, which: fakeWhich }, (env) => {
+      setOmxLookups(env, ["/tmp/omx", ""])
+
+      // when
+      const result = spawnSync(process.execPath, [binPath, "install"], {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      })
+
+      // then
+      assert.equal(result.status, 0, result.stderr)
+      assert.equal(
+        readFileSync(env.LAZYCODEX_TEST_LOG, "utf8").trim(),
+        [
+          "omx uninstall --purge",
+          "npm uninstall -g oh-my-codex",
+          "bunx --package oh-my-openagent omo install --platform=codex",
+        ].join("\n"),
+      )
+    })
+  })
+
+  it("does not remove oh-my-codex before non-install commands", () => {
+    // given
+    assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
+
+    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm, which: fakeWhich }, (env) => {
+      setOmxLookups(env, ["/tmp/omx"])
+
+      // when
+      const result = spawnSync(process.execPath, [binPath, "doctor"], {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      })
+
+      // then
+      assert.equal(result.status, 0, result.stderr)
+      assert.equal(readFileSync(env.LAZYCODEX_TEST_LOG, "utf8").trim(), "bunx --package oh-my-openagent omo doctor")
+    })
+  })
+
+  it("aborts install when oh-my-codex cleanup fails", () => {
+    // given
+    assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
+    const failingOmx = `#!/bin/sh
+printf 'omx %s\n' "$*" >> "$LAZYCODEX_TEST_LOG"
+exit 42
+`
+
+    withFakeBin({ bunx: fakeBunx, omx: failingOmx, npm: fakeNpm, which: fakeWhich }, (env) => {
+      setOmxLookups(env, ["/tmp/omx"])
+
+      // when
+      const result = spawnSync(process.execPath, [binPath, "install"], {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      })
+
+      // then
+      assert.equal(result.status, 1)
+      assert.match(result.stderr, /oh-my-codex cleanup failed/)
+      assert.equal(readFileSync(env.LAZYCODEX_TEST_LOG, "utf8").trim(), "omx uninstall --purge")
+    })
+  })
+
+  it("skips omx uninstall when omx is not installed", () => {
+    // given
+    assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
+
+    withFakeBin({ bunx: fakeBunx, npm: fakeNpm, which: fakeWhich }, (env) => {
+      setOmxLookups(env, ["", ""])
+
+      // when
+      const result = spawnSync(process.execPath, [binPath, "install"], {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      })
+
+      // then
+      assert.equal(result.status, 0, result.stderr)
+      assert.equal(
+        readFileSync(env.LAZYCODEX_TEST_LOG, "utf8").trim(),
+        [
+          "npm uninstall -g oh-my-codex",
+          "bunx --package oh-my-openagent omo install --platform=codex",
+        ].join("\n"),
+      )
+    })
+  })
+
+  it("aborts install when omx is still installed after cleanup", () => {
+    // given
+    assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
+
+    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm, which: fakeWhich }, (env) => {
+      setOmxLookups(env, ["/tmp/omx", "/tmp/stale-omx", "/tmp/stale-omx"])
+
+      // when
+      const result = spawnSync(process.execPath, [binPath, "install"], {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      })
+
+      // then
+      assert.equal(result.status, 1)
+      assert.match(result.stderr, /omx is still installed at \/tmp\/stale-omx/)
+      assert.equal(
+        readFileSync(env.LAZYCODEX_TEST_LOG, "utf8").trim(),
+        ["omx uninstall --purge", "npm uninstall -g oh-my-codex"].join("\n"),
+      )
+    })
+  })
+
+  it("removes a leftover omx executable after npm cleanup", () => {
+    // given
+    assert.equal(existsSync(binPath), true, "lazycodex-ai bin must exist")
+
+    withFakeBin({ bunx: fakeBunx, omx: fakeOmx, npm: fakeNpm, which: fakeWhich, rm: fakeRm }, (env) => {
+      const staleOmxPath = join(env.tempDir, "omx")
+      setOmxLookups(env, [staleOmxPath, staleOmxPath, ""])
+
+      // when
+      const result = spawnSync(process.execPath, [binPath, "install"], {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      })
+
+      // then
+      assert.equal(result.status, 0, result.stderr)
+      assert.equal(existsSync(staleOmxPath), false, "stale omx executable should be removed")
+      assert.equal(
+        readFileSync(env.LAZYCODEX_TEST_LOG, "utf8").trim(),
+        [
+          "omx uninstall --purge",
+          "npm uninstall -g oh-my-codex",
+          `rm ${staleOmxPath}`,
+          "bunx --package oh-my-openagent omo install --platform=codex",
+        ].join("\n"),
+      )
+      assert.equal(basename(staleOmxPath), "omx")
+    })
   })
 
   it("dry-runs non-install commands through oh-my-openagent", () => {


### PR DESCRIPTION
## Summary

* clean up existing oh-my-codex before running lazycodex install
* abort install when cleanup fails or omx still resolves afterward
* preserve non-install command forwarding

## Verification

* **RED**: new tests failed before implementation for missing cleanup order, cleanup failure handling, stale omx verification, and leftover executable removal
* **GREEN**: npm test (9/9 passing)
* `npm run pack:dry-run`
* `node bin/lazycodex-ai.js --dry-run install --no-tui --codex-autonomous`
* `node bin/lazycodex-ai.js --dry-run doctor`
* **local baseline before**: `command -v omx` -> `/Users/minpeter/.local/bin/omx`; `omx --version` -> `oh-my-codex v0.18.2`; `npm global oh-my-codex@0.18.2`
* **real local install**: `node bin/lazycodex-ai.js install --no-tui --codex-autonomous` completed LazyCodex install after cleanup
* **local verification after**: `command -v omx` produced no output; `npm ls -g oh-my-codex --depth=0` showed empty
* `lsp_diagnostics` clean for changed files
* Oracle review: unconditional approval

> **Note:** `bunx --package oh-my-openagent omo doctor` returns unknown command in the Codex adapter, so the install completion plus omx absence checks were used as the real-surface verification.

---

## Summary by cubic

Remove `oh-my-codex` before running install to prevent conflicts and ensure a clean `LazyCodex` setup. Hardened cleanup deletes residue, skips unnecessary steps, and aborts if cleanup fails or `omx` remains on PATH; non-install commands are unchanged.

* **Bug Fixes**
* On `install`, run `omx uninstall --purge` and `npm uninstall -g oh-my-codex`, then remove known residue (`CODEX_HOME/plugins/cache/oh-my-codex-local`, project `.omx`) and any leftover `omx` binary.
* Verify `omx` is gone; abort with an error if any cleanup step fails or `omx` still resolves.
* Skip `omx uninstall` when `omx` is not on PATH; skip cleanup for non-install commands; dry-run prints the cleanup and `bunx` commands.
* Added tests for residue removal, skip-when-missing, cleanup order, failure handling, and command forwarding.



<sup>Written for commit b3acf6ff09835c55cc1279a98f9222d0e694a805. Summary will update on new commits.</sup>

<a href="[https://cubic.dev/pr/code-yeongyu/lazycodex/pull/2?utm_source=github](https://cubic.dev/pr/code-yeongyu/lazycodex/pull/2?utm_source=github)" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="[https://cubic.dev/buttons/review-in-cubic-dark.svg](https://cubic.dev/buttons/review-in-cubic-dark.svg)"><source media="(prefers-color-scheme: light)" srcset="[https://cubic.dev/buttons/review-in-cubic-light.svg](https://cubic.dev/buttons/review-in-cubic-light.svg)"><img alt="Review in cubic" src="[https://cubic.dev/buttons/review-in-cubic-dark.svg](https://cubic.dev/buttons/review-in-cubic-dark.svg)"></picture></a>