### PR TITLE
ci(npm): add published lazycodex-ai smoke checks

### DIFF
--- a/.github/workflows/npm-registry-smoke.yml
+++ b/.github/workflows/npm-registry-smoke.yml
@@ -1,0 +1,44 @@
+name: NPM Registry Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_version:
+        description: "lazycodex-ai npm version or dist-tag to test"
+        required: false
+        default: "latest"
+  schedule:
+    - cron: "17 9 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-registry-smoke-${{ github.event.inputs.package_version || 'latest' }}
+  cancel-in-progress: false
+
+jobs:
+  published-package-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      LAZYCODEX_AI_SMOKE_VERSION: ${{ github.event.inputs.package_version || 'latest' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Use Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Smoke published lazycodex-ai
+        run: npm run smoke:published

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "test": "node --test test/lazycodex-ai-bin.test.mjs",
-    "pack:dry-run": "npm pack --dry-run"
+    "pack:dry-run": "npm pack --dry-run",
+    "smoke:published": "node scripts/smoke-published-lazycodex-ai.mjs"
   },
   "keywords": [
     "codex",

--- a/scripts/smoke-published-lazycodex-ai.mjs
+++ b/scripts/smoke-published-lazycodex-ai.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const version = process.env.LAZYCODEX_AI_SMOKE_VERSION || "latest"
+const packageSpec = `lazycodex-ai@${version}`
+const tempDir = mkdtempSync(join(tmpdir(), "lazycodex-ai-smoke-"))
+
+function commandName(name) {
+  return process.platform === "win32" ? `${name}.cmd` : name
+}
+
+function runSmoke({ label, command, args, expectedStdout }) {
+  console.log(`::group::${label}`)
+  console.log(`cwd: ${tempDir}`)
+  console.log(`$ ${[command, ...args].join(" ")}`)
+
+  const result = spawnSync(commandName(command), args, {
+    cwd: tempDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      npm_config_yes: "true",
+    },
+  })
+
+  const stdout = result.stdout.trim()
+  const stderr = result.stderr.trim()
+
+  if (stdout) console.log(stdout)
+  if (stderr) console.error(stderr)
+  console.log("::endgroup::")
+
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`${label} exited with status ${result.status}`)
+  }
+  if (stdout !== expectedStdout) {
+    throw new Error(`${label} printed unexpected stdout:\nexpected: ${expectedStdout}\nactual:   ${stdout}`)
+  }
+}
+
+try {
+  runSmoke({
+    label: "bunx install dry-run",
+    command: "bunx",
+    args: [packageSpec, "--dry-run", "install", "--no-tui", "--codex-autonomous"],
+    expectedStdout: "bunx --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous",
+  })
+
+  runSmoke({
+    label: "npx doctor dry-run",
+    command: "npx",
+    args: ["-y", packageSpec, "--dry-run", "doctor"],
+    expectedStdout: "bunx --package oh-my-openagent omo doctor",
+  })
+} finally {
+  rmSync(tempDir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

Closes #4.

Adds a published-package smoke check for `lazycodex-ai` so CI verifies the real npm install entrypoint from a clean temporary directory.

The check covers:

- `bunx lazycodex-ai@latest --dry-run install --no-tui --codex-autonomous`
- `npx -y lazycodex-ai@latest --dry-run doctor`

Both commands must route through `oh-my-openagent` / `omo` as expected.

## Validation

- `git diff --check`
- `npm test`
- `npm run pack:dry-run -- --json`
- `npm run smoke:published`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CI smoke tests for the published `lazycodex-ai` to ensure `bunx`/`npx` dry-runs route through `oh-my-openagent` (`omo`) from a clean temp dir. Runs manually or nightly to catch registry and entrypoint regressions.

- **New Features**
  - Adds `npm-registry-smoke.yml` workflow with version-concurrency and a daily cron.
  - Validates `bunx` install dry-run and `npx` doctor dry-run, asserting expected `omo` stdout.
  - Supports version/dist-tag via `LAZYCODEX_AI_SMOKE_VERSION` (default `latest`).
  - Adds `smoke:published` script to run the check.

<sup>Written for commit 818a1f9c350aaa1208601eedd82429916483c11f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

