### PR TITLE
fix(omo): use non-full-history forks for role spawns

### DIFF
--- a/plugins/omo/components/rules/bundled-rules/hephaestus.md
+++ b/plugins/omo/components/rules/bundled-rules/hephaestus.md
@@ -79,10 +79,10 @@ omo-codex bundles three read-only Codex subagent roles in `CODEX_HOME/agents/`: 
 
 **Routing:**
 
-- "Where is X?" / "Find code that does Y" -> `spawn_agent(agent_type="explorer", ...)`
-- "How does library Z work?" / "What's the API contract?" -> `spawn_agent(agent_type="librarian", ...)`
-- 5+ interdependent steps, ambiguous scope, multi-module work -> `spawn_agent(agent_type="plan", ...)`
-- Heavy verification of a finished change -> `spawn_agent(agent_type="codex-ultrawork-reviewer", ...)`
+- "Where is X?" / "Find code that does Y" -> `spawn_agent(agent_type="explorer", fork_turns="none", ...)`
+- "How does library Z work?" / "What's the API contract?" -> `spawn_agent(agent_type="librarian", fork_turns="none", ...)`
+- 5+ interdependent steps, ambiguous scope, multi-module work -> `spawn_agent(agent_type="plan", fork_turns="none", ...)`
+- Heavy verification of a finished change -> `spawn_agent(agent_type="codex-ultrawork-reviewer", fork_turns="none", ...)`
 
 **Don't duplicate.** Once a subagent is dispatched for a question, do not re-do the same search yourself. Once results return, do not re-verify by repeating their tool calls; integrate and move on.
 

--- a/plugins/omo/scripts/sync-skills.mjs
+++ b/plugins/omo/scripts/sync-skills.mjs
@@ -21,15 +21,15 @@ This skill may include examples copied from the OpenCode harness. In Codex, do n
 
 | OpenCode example | Codex tool to use |
 | --- | --- |
-| \`call_omo_agent(subagent_type="explore", ...)\` | \`spawn_agent(agent_type="explorer", task_name="...", message="...")\` |
-| \`call_omo_agent(subagent_type="librarian", ...)\` | \`spawn_agent(agent_type="librarian", task_name="...", message="...")\` |
-| \`task(subagent_type="plan", ...)\` | \`spawn_agent(agent_type="plan", task_name="...", message="...")\` |
-| \`task(subagent_type="oracle", ...)\` for final verification | \`spawn_agent(agent_type="codex-ultrawork-reviewer", task_name="...", message="...")\` |
-| \`task(category="...", ...)\` for implementation or QA | \`spawn_agent(agent_type="worker", task_name="...", message="...")\` |
+| \`call_omo_agent(subagent_type="explore", ...)\` | \`spawn_agent(agent_type="explorer", task_name="...", message="...", fork_turns="none")\` |
+| \`call_omo_agent(subagent_type="librarian", ...)\` | \`spawn_agent(agent_type="librarian", task_name="...", message="...", fork_turns="none")\` |
+| \`task(subagent_type="plan", ...)\` | \`spawn_agent(agent_type="plan", task_name="...", message="...", fork_turns="none")\` |
+| \`task(subagent_type="oracle", ...)\` for final verification | \`spawn_agent(agent_type="codex-ultrawork-reviewer", task_name="...", message="...", fork_turns="none")\` |
+| \`task(category="...", ...)\` for implementation or QA | \`spawn_agent(agent_type="worker", task_name="...", message="...", fork_turns="none")\` |
 | \`background_output(task_id="...")\` | \`wait_agent(...)\` to wait for subagent completion and mailbox updates |
 | \`team_*(...)\` | Use Codex native subagents plus \`send_message\`, \`followup_task\`, \`wait_agent\`, and \`close_agent\` |
 
-When translating \`load_skills=[...]\`, include the requested skill names in the spawned agent's \`message\`. If a code block below conflicts with this section, this section wins.
+Codex full-history forks inherit the parent agent type, model, and reasoning effort, so role-specific spawns with \`agent_type\` must use a non-full-history fork mode such as \`fork_turns="none"\`. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's \`message\`. If a code block below conflicts with this section, this section wins.
 
 `;
 

--- a/plugins/omo/skills/refactor/SKILL.md
+++ b/plugins/omo/skills/refactor/SKILL.md
@@ -9,15 +9,15 @@ This skill may include examples copied from the OpenCode harness. In Codex, do n
 
 | OpenCode example | Codex tool to use |
 | --- | --- |
-| `call_omo_agent(subagent_type="explore", ...)` | `spawn_agent(agent_type="explorer", task_name="...", message="...")` |
-| `call_omo_agent(subagent_type="librarian", ...)` | `spawn_agent(agent_type="librarian", task_name="...", message="...")` |
-| `task(subagent_type="plan", ...)` | `spawn_agent(agent_type="plan", task_name="...", message="...")` |
-| `task(subagent_type="oracle", ...)` for final verification | `spawn_agent(agent_type="codex-ultrawork-reviewer", task_name="...", message="...")` |
-| `task(category="...", ...)` for implementation or QA | `spawn_agent(agent_type="worker", task_name="...", message="...")` |
+| `call_omo_agent(subagent_type="explore", ...)` | `spawn_agent(agent_type="explorer", task_name="...", message="...", fork_turns="none")` |
+| `call_omo_agent(subagent_type="librarian", ...)` | `spawn_agent(agent_type="librarian", task_name="...", message="...", fork_turns="none")` |
+| `task(subagent_type="plan", ...)` | `spawn_agent(agent_type="plan", task_name="...", message="...", fork_turns="none")` |
+| `task(subagent_type="oracle", ...)` for final verification | `spawn_agent(agent_type="codex-ultrawork-reviewer", task_name="...", message="...", fork_turns="none")` |
+| `task(category="...", ...)` for implementation or QA | `spawn_agent(agent_type="worker", task_name="...", message="...", fork_turns="none")` |
 | `background_output(task_id="...")` | `wait_agent(...)` to wait for subagent completion and mailbox updates |
 | `team_*(...)` | Use Codex native subagents plus `send_message`, `followup_task`, `wait_agent`, and `close_agent` |
 
-When translating `load_skills=[...]`, include the requested skill names in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.
+Codex full-history forks inherit the parent agent type, model, and reasoning effort, so role-specific spawns with `agent_type` must use a non-full-history fork mode such as `fork_turns="none"`. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.
 
 export const REFACTOR_TEMPLATE = `# Intelligent Refactor Command
 

--- a/plugins/omo/skills/remove-ai-slops/SKILL.md
+++ b/plugins/omo/skills/remove-ai-slops/SKILL.md
@@ -9,15 +9,15 @@ This skill may include examples copied from the OpenCode harness. In Codex, do n
 
 | OpenCode example | Codex tool to use |
 | --- | --- |
-| `call_omo_agent(subagent_type="explore", ...)` | `spawn_agent(agent_type="explorer", task_name="...", message="...")` |
-| `call_omo_agent(subagent_type="librarian", ...)` | `spawn_agent(agent_type="librarian", task_name="...", message="...")` |
-| `task(subagent_type="plan", ...)` | `spawn_agent(agent_type="plan", task_name="...", message="...")` |
-| `task(subagent_type="oracle", ...)` for final verification | `spawn_agent(agent_type="codex-ultrawork-reviewer", task_name="...", message="...")` |
-| `task(category="...", ...)` for implementation or QA | `spawn_agent(agent_type="worker", task_name="...", message="...")` |
+| `call_omo_agent(subagent_type="explore", ...)` | `spawn_agent(agent_type="explorer", task_name="...", message="...", fork_turns="none")` |
+| `call_omo_agent(subagent_type="librarian", ...)` | `spawn_agent(agent_type="librarian", task_name="...", message="...", fork_turns="none")` |
+| `task(subagent_type="plan", ...)` | `spawn_agent(agent_type="plan", task_name="...", message="...", fork_turns="none")` |
+| `task(subagent_type="oracle", ...)` for final verification | `spawn_agent(agent_type="codex-ultrawork-reviewer", task_name="...", message="...", fork_turns="none")` |
+| `task(category="...", ...)` for implementation or QA | `spawn_agent(agent_type="worker", task_name="...", message="...", fork_turns="none")` |
 | `background_output(task_id="...")` | `wait_agent(...)` to wait for subagent completion and mailbox updates |
 | `team_*(...)` | Use Codex native subagents plus `send_message`, `followup_task`, `wait_agent`, and `close_agent` |
 
-When translating `load_skills=[...]`, include the requested skill names in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.
+Codex full-history forks inherit the parent agent type, model, and reasoning effort, so role-specific spawns with `agent_type` must use a non-full-history fork mode such as `fork_turns="none"`. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.
 
 # Remove AI Slops Skill
 

--- a/plugins/omo/skills/review-work/SKILL.md
+++ b/plugins/omo/skills/review-work/SKILL.md
@@ -8,15 +8,15 @@ This skill may include examples copied from the OpenCode harness. In Codex, do n
 
 | OpenCode example | Codex tool to use |
 | --- | --- |
-| `call_omo_agent(subagent_type="explore", ...)` | `spawn_agent(agent_type="explorer", task_name="...", message="...")` |
-| `call_omo_agent(subagent_type="librarian", ...)` | `spawn_agent(agent_type="librarian", task_name="...", message="...")` |
-| `task(subagent_type="plan", ...)` | `spawn_agent(agent_type="plan", task_name="...", message="...")` |
-| `task(subagent_type="oracle", ...)` for final verification | `spawn_agent(agent_type="codex-ultrawork-reviewer", task_name="...", message="...")` |
-| `task(category="...", ...)` for implementation or QA | `spawn_agent(agent_type="worker", task_name="...", message="...")` |
+| `call_omo_agent(subagent_type="explore", ...)` | `spawn_agent(agent_type="explorer", task_name="...", message="...", fork_turns="none")` |
+| `call_omo_agent(subagent_type="librarian", ...)` | `spawn_agent(agent_type="librarian", task_name="...", message="...", fork_turns="none")` |
+| `task(subagent_type="plan", ...)` | `spawn_agent(agent_type="plan", task_name="...", message="...", fork_turns="none")` |
+| `task(subagent_type="oracle", ...)` for final verification | `spawn_agent(agent_type="codex-ultrawork-reviewer", task_name="...", message="...", fork_turns="none")` |
+| `task(category="...", ...)` for implementation or QA | `spawn_agent(agent_type="worker", task_name="...", message="...", fork_turns="none")` |
 | `background_output(task_id="...")` | `wait_agent(...)` to wait for subagent completion and mailbox updates |
 | `team_*(...)` | Use Codex native subagents plus `send_message`, `followup_task`, `wait_agent`, and `close_agent` |
 
-When translating `load_skills=[...]`, include the requested skill names in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.
+Codex full-history forks inherit the parent agent type, model, and reasoning effort, so role-specific spawns with `agent_type` must use a non-full-history fork mode such as `fork_turns="none"`. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.
 
 # Review Work - 5-Agent Parallel Review Orchestrator
 

--- a/plugins/omo/test/aggregate.test.mjs
+++ b/plugins/omo/test/aggregate.test.mjs
@@ -176,15 +176,16 @@ test("#given synced skills with Codex compatibility guidance #when explorer/libr
 test('#given synced skills with Codex compatibility guidance #when role-specific agents are spawned #then they set fork_turns="none"', async () => {
 	const skillsDir = join(root, "skills");
 	const skillEntries = await readdir(skillsDir, { withFileTypes: true });
-	const skillFiles = skillEntries
+	const promptFiles = skillEntries
 		.filter((entry) => entry.isDirectory())
 		.map((entry) => join(skillsDir, entry.name, "SKILL.md"));
+	promptFiles.push(join(root, "components", "rules", "bundled-rules", "hephaestus.md"));
 
 	const missingForkTurns = [];
-	for (const skillPath of skillFiles) {
-		const content = await readFile(skillPath, "utf8");
+	for (const promptPath of promptFiles) {
+		const content = await readFile(promptPath, "utf8");
 		for (const call of findRoleSpecificSpawnsWithoutForkTurnsNone(content)) {
-			missingForkTurns.push(`${basename(dirname(skillPath))}: ${call}`);
+			missingForkTurns.push(`${basename(dirname(promptPath))}/${basename(promptPath)}: ${call}`);
 		}
 	}
 

--- a/plugins/omo/test/aggregate.test.mjs
+++ b/plugins/omo/test/aggregate.test.mjs
@@ -19,6 +19,18 @@ function findSpawnAgentTypes(content) {
 	return [...agentTypes].sort();
 }
 
+function findRoleSpecificSpawnsWithoutNonFullHistoryFork(content) {
+	const missingForkTurns = [];
+	const regex = /spawn_agent\(agent_type="([^"]+)"[^)]*\)/g;
+	for (const match of content.matchAll(regex)) {
+		const call = match[0];
+		if (!call.includes('fork_turns="none"')) {
+			missingForkTurns.push(call);
+		}
+	}
+	return missingForkTurns;
+}
+
 test("#given aggregate plugin manifest #when inspected #then it owns the omo namespace", async () => {
 	// given
 	const manifest = await readJson(".codex-plugin/plugin.json");
@@ -159,4 +171,22 @@ test("#given synced skills with Codex compatibility guidance #when explorer/libr
 		assert.equal(fileStat.isFile(), true);
 		assert.equal(basename(tomlPath), `${agentType}.toml`);
 	}
+});
+
+test("#given synced skills with Codex compatibility guidance #when role-specific agents are spawned #then they use non-full-history forks", async () => {
+	const skillsDir = join(root, "skills");
+	const skillEntries = await readdir(skillsDir, { withFileTypes: true });
+	const skillFiles = skillEntries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => join(skillsDir, entry.name, "SKILL.md"));
+
+	const missingForkTurns = [];
+	for (const skillPath of skillFiles) {
+		const content = await readFile(skillPath, "utf8");
+		for (const call of findRoleSpecificSpawnsWithoutNonFullHistoryFork(content)) {
+			missingForkTurns.push(`${basename(dirname(skillPath))}: ${call}`);
+		}
+	}
+
+	assert.deepEqual(missingForkTurns, []);
 });

--- a/plugins/omo/test/aggregate.test.mjs
+++ b/plugins/omo/test/aggregate.test.mjs
@@ -19,7 +19,7 @@ function findSpawnAgentTypes(content) {
 	return [...agentTypes].sort();
 }
 
-function findRoleSpecificSpawnsWithoutNonFullHistoryFork(content) {
+function findRoleSpecificSpawnsWithoutForkTurnsNone(content) {
 	const missingForkTurns = [];
 	const regex = /spawn_agent\(agent_type="([^"]+)"[^)]*\)/g;
 	for (const match of content.matchAll(regex)) {
@@ -173,7 +173,7 @@ test("#given synced skills with Codex compatibility guidance #when explorer/libr
 	}
 });
 
-test("#given synced skills with Codex compatibility guidance #when role-specific agents are spawned #then they use non-full-history forks", async () => {
+test('#given synced skills with Codex compatibility guidance #when role-specific agents are spawned #then they set fork_turns="none"', async () => {
 	const skillsDir = join(root, "skills");
 	const skillEntries = await readdir(skillsDir, { withFileTypes: true });
 	const skillFiles = skillEntries
@@ -183,7 +183,7 @@ test("#given synced skills with Codex compatibility guidance #when role-specific
 	const missingForkTurns = [];
 	for (const skillPath of skillFiles) {
 		const content = await readFile(skillPath, "utf8");
-		for (const call of findRoleSpecificSpawnsWithoutNonFullHistoryFork(content)) {
+		for (const call of findRoleSpecificSpawnsWithoutForkTurnsNone(content)) {
 			missingForkTurns.push(`${basename(dirname(skillPath))}: ${call}`);
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #10.

Updates the OMO Codex compatibility guidance so OpenCode-style role-specific subagent calls are translated to `spawn_agent(..., fork_turns="none")`.

This avoids Codex harness failures where the default full-history fork conflicts with explicit `agent_type` overrides.

## Changes

- Add `fork_turns="none"` to role-specific `spawn_agent(agent_type=...)` examples in the shared sync guidance.
- Reflect the generated guidance in the synced OMO skill files.
- Add the same guidance to the bundled Hephaestus rule prompt, which is another installed prompt surface that can route role-specific agents.
- Clarify that required conversation context, diffs, files, constraints, and skill names should be included directly in the spawned agent message when using non-full-history forks.
- Add/extend aggregate coverage to catch role-specific spawn examples in skills and bundled rules that omit `fork_turns="none"`.

## Verification

- `git diff --check`
- `node --test --test-name-pattern 'fork_turns="none"' plugins/omo/test/aggregate.test.mjs`
- Slurped scan of `spawn_agent(agent_type=...)` calls under `plugins/omo/skills`, `plugins/omo/scripts/sync-skills.mjs`, and `plugins/omo/components/rules/bundled-rules/hephaestus.md` returned no calls missing `fork_turns="none"`.

Note: `npm test --prefix plugins/omo` currently fails on an unrelated existing path issue while reading `plugins/scripts/sync-telemetry-component.mjs`; the new role-specific fork test passes.
