### PR TITLE
fix(config): Skip symlinked project Codex configs

### DIFF
--- a/plugins/omo/scripts/migrate-codex-config.mjs
+++ b/plugins/omo/scripts/migrate-codex-config.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -169,7 +169,7 @@ async function configPaths({ env, cwd }) {
 	const codexHome = resolve(env.CODEX_HOME?.trim() || join(homedir(), ".codex"));
 	const paths = new Set([join(codexHome, "config.toml")]);
 	for (const projectConfig of projectConfigPaths({ cwd, stopAt: homedir() })) {
-		if (await pathExists(projectConfig)) paths.add(projectConfig);
+		if (await isSafeProjectConfig(projectConfig)) paths.add(projectConfig);
 	}
 	return [...paths];
 }
@@ -216,12 +216,22 @@ async function writeState(statePath, state) {
 	await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
 }
 
-async function pathExists(path) {
+async function isSafeProjectConfig(configPath) {
+	if (!(await isRegularDirectory(dirname(configPath)))) return false;
+	const entry = await lstatIfExists(configPath);
+	return entry?.isFile() === true && !entry.isSymbolicLink();
+}
+
+async function isRegularDirectory(path) {
+	const entry = await lstatIfExists(path);
+	return entry?.isDirectory() === true && !entry.isSymbolicLink();
+}
+
+async function lstatIfExists(path) {
 	try {
-		await stat(path);
-		return true;
+		return await lstat(path);
 	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
 		throw error;
 	}
 }

--- a/plugins/omo/test/migrate-codex-config.test.mjs
+++ b/plugins/omo/test/migrate-codex-config.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -50,6 +50,49 @@ test("#given global and project-local stale Codex configs #when migrating #then 
 	assert.deepEqual(result.changed.sort(), [join(codexHome, "config.toml"), projectConfig].sort());
 	assert.match(await readFile(join(codexHome, "config.toml"), "utf8"), /model = "gpt-5\.5"/);
 	assert.match(await readFile(projectConfig, "utf8"), /model_context_window = 400000/);
+});
+
+test("#given project-local Codex config is a symlink #when migrating #then symlink target is not modified", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-config-symlink-"));
+	const codexHome = join(root, "codex-home");
+	const project = join(root, "project");
+	const projectConfig = join(project, ".codex", "config.toml");
+	const victim = join(root, "victim.toml");
+	await mkdir(codexHome, { recursive: true });
+	await mkdir(dirname(projectConfig), { recursive: true });
+	await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.2"\n');
+	await writeFile(victim, "");
+	await symlink(victim, projectConfig);
+
+	const result = await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json") },
+		cwd: project,
+	});
+
+	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
+	assert.equal(await readFile(victim, "utf8"), "");
+});
+
+test("#given project-local .codex directory is a symlink #when migrating #then symlink target is not modified", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-config-dir-symlink-"));
+	const codexHome = join(root, "codex-home");
+	const project = join(root, "project");
+	const outsideCodex = join(root, "outside-codex");
+	const outsideConfig = join(outsideCodex, "config.toml");
+	await mkdir(codexHome, { recursive: true });
+	await mkdir(project, { recursive: true });
+	await mkdir(outsideCodex, { recursive: true });
+	await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.2"\n');
+	await writeFile(outsideConfig, "");
+	await symlink(outsideCodex, join(project, ".codex"), "dir");
+
+	const result = await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json") },
+		cwd: project,
+	});
+
+	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
+	assert.equal(await readFile(outsideConfig, "utf8"), "");
 });
 
 test("#given user-customized Codex model config #when migrating #then user values are preserved", async () => {


### PR DESCRIPTION
## Summary
- Skip project `.codex/config.toml` migration when either the project `.codex` directory or `config.toml` entry is a symlink.
- Preserve normal `CODEX_HOME/config.toml` migration behavior.
- Add regression coverage for symlinked config files and symlinked project `.codex` directories.

## Verification
- `bun test plugins/omo/test/migrate-codex-config.test.mjs`
- `bun test plugins/omo/test/migrate-codex-config.test.mjs plugins/omo/test/auto-update.test.mjs`
- Manual startup-surface probe with `runAutoUpdateCheck()` in a disposable repo: updater disabled, home config migrated, symlink victim unchanged.

## Notes
- `bun run test` still fails in pre-existing `test/no-bunx-text.test.mjs` because tracked programming-skill docs/tests contain old package-runner text. That failure is outside this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip migrating project `.codex/config.toml` when the file or the `.codex` directory is a symlink to avoid modifying symlink targets. Normal `CODEX_HOME/config.toml` migration is unchanged.

- **Bug Fixes**
  - Treat project config as eligible only if both the file and its `.codex` directory are regular (non-symlink) entries using `lstat`.
  - Added tests for symlinked config files and symlinked `.codex` directories to ensure only the home config is migrated.

<sup>Written for commit ae12b7fb6db6f26f0ff85e0c7973e5554dabe5b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

