### PR TITLE
fix(bin): distinguish ENOENT from other spawn failures

### DIFF
--- a/bin/lazycodex-ai.js
+++ b/bin/lazycodex-ai.js
@@ -28,7 +28,11 @@ const result = spawnSync("npx", commandArgs, {
 })
 
 if (result.error) {
-  console.error(result.error.message)
+  if (result.error.code === "ENOENT") {
+    console.error("npx not found on PATH. Install Node.js 20+ from https://nodejs.org.")
+  } else {
+    console.error(result.error.message)
+  }
   process.exit(1)
 }
 

--- a/test/bin-spawn-error.test.mjs
+++ b/test/bin-spawn-error.test.mjs
@@ -1,0 +1,28 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const bin = join(here, "..", "bin", "lazycodex-ai.js")
+
+describe("bin/lazycodex-ai.js spawn error handling", () => {
+  it("prints a clear message and exits 1 when npx is not on PATH", () => {
+    // Force ENOENT by stripping PATH to an empty string for the child.
+    let stderr = ""
+    let code = 0
+    try {
+      execFileSync(process.execPath, [bin, "--help"], {
+        stdio: "pipe",
+        env: { ...process.env, PATH: "" },
+      })
+    } catch (e) {
+      stderr = e.stderr ? e.stderr.toString() : String(e)
+      code = e.status ?? 1
+    }
+    assert.equal(code, 1)
+    assert.match(stderr, /npx not found/, "stderr should mention missing npx")
+    assert.match(stderr, /Node\.js/, "stderr should suggest installing Node.js")
+  })
+})


### PR DESCRIPTION
## Problem

`bin/lazycodex-ai.js` shells out to `npx` via `spawnSync`. When the user's `PATH` is missing `npx` (no Node.js installed, or a sandboxed environment that strips npx), the existing code prints the raw syscall error and exits 1. The error gives no hint that the actual problem is a missing `npx`, and no hint about what to do (install Node.js).

## What changed

- Branch on `result.error.code === "ENOENT"` in `bin/lazycodex-ai.js` and print `"npx not found on PATH. Install Node.js 20+ from https://nodejs.org."` in that case.
- All other spawn errors fall through to the existing `result.error.message` print.
- Added `test/bin-spawn-error.test.mjs` to assert the new behavior. Test runs the bin with `PATH=""` to force ENOENT, captures stderr, and asserts the message mentions `npx` and `Node.js`. Test passes locally with `node --test test/*.test.mjs`.

## Why this fits

Tiny, focused, no behavior change for valid input. Matches the style of the existing bin script (no external deps, plain Node).

## Test

```sh
$ node --test test/*.test.mjs
ok 1 - bin/lazycodex-ai.js spawn error handling
# tests 1
# pass 1
# fail 0
```

Manual:
```sh
$ PATH= node bin/lazycodex-ai.js --help
npx not found on PATH. Install Node.js 20+ from https://nodejs.org.
```

No related issue — this is a clear UX gap observed by running the bin in a fresh container.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve bin error message when `npx` is not on PATH by detecting `ENOENT` and guiding users to install Node.js 20+. Adds a test to verify the behavior.

- **Bug Fixes**
  - Detect `ENOENT` from `spawnSync` and print "npx not found on PATH. Install Node.js 20+ from https://nodejs.org."; other errors stay the same.
  - Add `test/bin-spawn-error.test.mjs` to run with empty `PATH`, asserting the message and exit code 1.

<sup>Written for commit d40a0cb9c43f14e878255ee31d4ce1cb51f510c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

