### PR TITLE
fix(ultrawork): add subagent-dependent transition barrier

### DIFF
--- a/plugins/omo/components/ultrawork/directive.md
+++ b/plugins/omo/components/ultrawork/directive.md
@@ -254,6 +254,32 @@ silent or ack-only, record the result as inconclusive, do not count it
 as approval/pass, close it if safe, and respawn a smaller
 `fork_turns: "none"` task with the missing deliverable.
 
+
+# Subagent-dependent transition barrier
+
+BEFORE advancing any state that depends on a spawned child agent, verify
+the child has returned a substantive result or been recorded as
+inconclusive. Moving dependent work forward without collecting child
+output is a defect.
+
+a) **Before marking a dependent plan step complete** via `update_plan`,
+verify that any spawned child agent owning evidence for that step has
+returned a substantive result or been recorded as inconclusive. If a
+child is still active, do NOT mark the step complete.
+
+b) **Before generating or verifying a plan**, wait for all spawned
+research/metis/explorer agents to return. Use short `wait_agent` cycles
+(<=30s each), not a single long blocking wait.
+
+c) **Before final answer**, check that no child agents are still active.
+If any are running, close them (recording the result as inconclusive if
+no output received) or wait for them.
+
+d) **Short-poll enforcement**: Always use short `wait_agent` cycles.
+Never use a single long blocking wait. After two silent waits, send a
+targeted `TASK STILL ACTIVE` follow-up. After two more silent waits,
+close the child as inconclusive and respawn a smaller task if needed.
+
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 
 Trigger when ANY apply:

--- a/plugins/omo/test/subagent-guidance.test.mjs
+++ b/plugins/omo/test/subagent-guidance.test.mjs
@@ -63,6 +63,11 @@ test("#given ultrawork directive #when inspected #then reviewer fallback keeps a
 	assert.match(text, /timeout only means no new mailbox update arrived/i);
 	assert.match(text, /WORKING:/);
 	assert.match(text, /single `list_agents`/);
+	assert.match(text, /Subagent-dependent transition barrier/);
+	assert.match(text, /dependent plan step complete.*update_plan/s);
+	assert.match(text, /short `wait_agent` cycles.*<=30s/s);
+	assert.match(text, /single long blocking wait.*short `wait_agent`/s);
+	assert.match(text, /inconclusive.*close.*child/s);
 });
 
 test("#given ulw-loop workflow #when inspected #then stale review refresh keeps policy changes narrow", async () => {


### PR DESCRIPTION
## Summary

Adds an explicit `# Subagent-dependent transition barrier` section to the ultrawork directive (`directive.md`) that prevents dependent work from proceeding before spawned subagent results are collected or recorded as inconclusive.

Closes #30

## Problem

LazyCodex/OMO subagent orchestration can spawn planning, review, or audit agents and then move dependent work forward without collecting or integrating their result. The root agent marks dependent plan steps complete, starts implementation, or generates plans before spawned children return.

The root cause is that the waiting/integration rules are prompt-level guidance without a structural barrier preventing unsafe transitions.

## Changes

- **directive.md**: New `# Subagent-dependent transition barrier` section after `# Codex subagent reliability` with four rules:
  - Block `update_plan` step completion when child agents owning evidence are still active
  - Wait for all research/metis/explorer agents before plan generation, using short poll cycles
  - Ensure no child agents are running before final answer
  - Short-poll enforcement: short `wait_agent` cycles only, escalate after two silent waits, close as inconclusive after four

- **subagent-guidance.test.mjs**: Added 5 new assertion patterns to the ultrawork directive test covering the barrier section header, dependent step blocking, short-poll enforcement, and inconclusive handling.

## Testing

- `npm test` in ultrawork component: 18/18 passed
- `node --test plugins/omo/test/subagent-guidance.test.mjs`: 4/4 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a subagent-dependent transition barrier to the ultrawork directive to stop dependent work from advancing before child agents return or are marked inconclusive. Resolves #30 by making wait-and-collect rules explicit and test-backed.

- **Bug Fixes**
  - `plugins/omo/components/ultrawork/directive.md`: New “Subagent-dependent transition barrier” rules to block `update_plan` when a child owns evidence, wait for research/metis/explorer agents via short `wait_agent` cycles (<=30s), require no active children before final answer, and enforce short-poll escalation (follow-up after 2 silent waits, close after 4, respawn smaller if needed).
  - `plugins/omo/test/subagent-guidance.test.mjs`: +5 assertions verifying the barrier header, dependent-step blocking, short-polling, and inconclusive closure.

<sup>Written for commit 23a009ef02e30a8aabebced657f1261f2367c88b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

