### PR TITLE
fix(ultrawork): add TOML-backed subagent routing compatibility warning

### DIFF
--- a/plugins/omo/components/ultrawork/directive.md
+++ b/plugins/omo/components/ultrawork/directive.md
@@ -254,6 +254,38 @@ silent or ack-only, record the result as inconclusive, do not count it
 as approval/pass, close it if safe, and respawn a smaller
 `fork_turns: "none"` task with the missing deliverable.
 
+# TOML-backed subagent routing compatibility
+
+Native Codex `spawn_agent` accepts `task_name`, `fork_turns`, and
+`message` but does NOT expose `agent_type`, `model`, or
+`reasoning_effort`. The TOML agent files in `agents/*.toml` define
+role-specific model and reasoning settings, but those settings are NOT
+applied through the `spawn_agent` surface. Observe these rules:
+
+a) **Routing unverified by default**: When spawning subagents via native
+`spawn_agent`, the task name alone does NOT guarantee the TOML-backed
+agent role (model, reasoning effort, service tier) was selected. Treat
+all subagent spawns as using the default model/config unless runtime
+evidence confirms otherwise.
+
+b) **Compatibility warning**: If the orchestrator cannot confirm
+TOML-backed routing (because `spawn_agent` does not expose
+`agent_type`/`model`/`reasoning_effort`), mark the subagent
+result as `routing-unverified` and proceed with appropriate caution.
+Do not assume role-specific model or reasoning was applied.
+
+c) **Service tier validation**: If agent TOMLs reference `service_tier`
+values unsupported by the target model (e.g. `fast` for `gpt-5.5`),
+the orchestrator should not attempt to enforce that tier. Prefer
+omitting unsupported service tiers or mapping to the runtime-supported
+tier.
+
+d) **Fallback behavior**: While TOML-backed routing is not guaranteed
+through native `spawn_agent`, the task assignment pattern
+(TASK/DELIVERABLE/SCOPE/VERIFY) still provides sufficient structure for
+reliable subagent work. The TOML files serve as documentation of
+intent, not runtime configuration for `spawn_agent`.
+
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 
 Trigger when ANY apply:

--- a/plugins/omo/test/subagent-guidance.test.mjs
+++ b/plugins/omo/test/subagent-guidance.test.mjs
@@ -63,6 +63,10 @@ test("#given ultrawork directive #when inspected #then reviewer fallback keeps a
 	assert.match(text, /timeout only means no new mailbox update arrived/i);
 	assert.match(text, /WORKING:/);
 	assert.match(text, /single `list_agents`/);
+	assert.match(text, /TOML-backed/);
+	assert.match(text, /routing-unverified/);
+	assert.match(text, /service_tier/);
+
 });
 
 test("#given ulw-loop workflow #when inspected #then stale review refresh keeps policy changes narrow", async () => {


### PR DESCRIPTION
## Summary

Adds an explicit `# TOML-backed subagent routing compatibility` section to the ultrawork directive (`directive.md`) that warns when native `spawn_agent` cannot guarantee TOML-backed agent role selection.

Closes #32

## Problem

LazyCodex/OMO guidance implies ULW-triggered or role-named subagents (plan, reviewer, etc.) use configured Codex agent TOML files. However, the native Codex `spawn_agent` surface only accepts `task_name`, `fork_turns`, and `message` — not `agent_type`, `model`, or `reasoning_effort`. Users can believe TOML-backed routing was applied when it was not.

Additionally, installed TOMLs can contain `service_tier` values unsupported by the target model (e.g. `fast` for `gpt-5.5`), creating a compatibility hazard.

## Changes

- **directive.md**: New `# TOML-backed subagent routing compatibility` section after `# Codex subagent reliability` with four rules:
  - Routing is unverified by default — task name alone does not guarantee TOML-backed role
  - Compatibility warning when TOML routing cannot be confirmed
  - Service tier validation — do not attempt unsupported tiers
  - Fallback behavior documentation — TASK/DELIVERABLE/SCOPE/VERIFY pattern still works

- **subagent-guidance.test.mjs**: Added 3 new assertion patterns to the ultrawork directive test covering TOML routing language, routing-unverified, and service_tier compatibility.

## Testing

- `npm test` in ultrawork component: 18/18 passed
- `node --test plugins/omo/test/subagent-guidance.test.mjs`: 4/4 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TOML-backed subagent routing compatibility warning to the ultrawork directive, clarifying that native `spawn_agent` doesn’t apply TOML role settings. Adds tests for the `routing-unverified` state and `service_tier` compatibility; addresses #32.

- **Bug Fixes**
  - Directive: new section with rules for unverified routing, a compatibility warning, `service_tier` validation, and fallback behavior (TASK/DELIVERABLE/SCOPE/VERIFY).
  - Tests: assertions for TOML routing text, `routing-unverified`, and `service_tier` language.

<sup>Written for commit 5f3281139f90ae2c15309d5187f341b7bab28ced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

