### PR TITLE
Fix ULW component CLI direct subcommand dispatch

### DIFF
--- a/plugins/omo/components/ulw-loop/src/cli.ts
+++ b/plugins/omo/components/ulw-loop/src/cli.ts
@@ -5,14 +5,30 @@ import { runPreToolUseGoalBudgetGuardCli, runUlwLoopHookCli } from "./codex-hook
 const TOP_LEVEL_HELP =
 	"Usage:\n  omo ulw-loop <subcommand> [args]\n  omo hook user-prompt-submit         (Codex UserPromptSubmit hook)\n  omo help | --help | -h              (this message)\n\nRun `omo ulw-loop help` for ulw-loop subcommands.\n";
 
+const ULW_LOOP_DIRECT_COMMANDS = new Set([
+	"help",
+	"--help",
+	"-h",
+	"create-goals",
+	"status",
+	"complete-goals",
+	"checkpoint",
+	"steer",
+	"add-goal",
+	"criteria",
+	"record-evidence",
+	"record-review-blockers",
+]);
+
 async function main(): Promise<number> {
 	const argv = process.argv.slice(2);
 	const command = argv[0];
-	if (command === undefined || command === "help" || command === "--help" || command === "-h") {
+	if (command === undefined) {
 		process.stdout.write(TOP_LEVEL_HELP);
 		return 0;
 	}
 	if (command === "ulw-loop") return ulwLoopCommand(argv.slice(1));
+	if (ULW_LOOP_DIRECT_COMMANDS.has(command)) return ulwLoopCommand(argv);
 	if (command === "hook") {
 		const sub = argv[1];
 		if (sub === "user-prompt-submit") {

--- a/plugins/omo/components/ulw-loop/test/cli-entrypoint.test.ts
+++ b/plugins/omo/components/ulw-loop/test/cli-entrypoint.test.ts
@@ -1,0 +1,36 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = resolve(import.meta.dirname, "..");
+let qaRoot = "";
+
+beforeAll(async () => {
+	await execFileAsync("npm", ["run", "build"], { cwd: repoRoot });
+	qaRoot = await mkdtemp(join(tmpdir(), "omo-ulw-loop-cli-entrypoint-"));
+});
+
+afterAll(async () => {
+	if (qaRoot) await rm(qaRoot, { recursive: true, force: true });
+});
+
+describe("dist/cli.js component entrypoint", () => {
+	it("dispatches direct subcommands when invoked as omo-ulw-loop", async () => {
+		const cliPath = join(repoRoot, "dist", "cli.js");
+		const result = await execFileAsync(process.execPath, [cliPath, "status", "--json"], { cwd: qaRoot }).catch(
+			(error: unknown) => {
+				if (error instanceof Error && "stderr" in error && "stdout" in error) {
+					return error as Error & { readonly stdout: string; readonly stderr: string };
+				}
+				throw error;
+			},
+		);
+
+		expect(result.stderr).toContain("[ulw-loop] No ulw-loop plan found");
+		expect(result.stderr).not.toContain("[omo] unknown command: status");
+	});
+});


### PR DESCRIPTION
## Problem Situation
`omo ulw-loop status --json` can fail after the OMO wrapper strips the `ulw-loop` prefix and invokes the `omo-ulw-loop` component binary, because the component entrypoint rejects direct subcommands such as `status`.

## Reproduction Logs
RED: `npm test -- test/cli-entrypoint.test.ts` failed with `AssertionError: expected '[omo] unknown command: status
Usage:…' to contain '[ulw-loop] No ulw-loop plan found'`.

## Approach
Keep the existing `ulw-loop <subcommand>` and `hook ...` paths, but also dispatch known direct ULW subcommands to `ulwLoopCommand(argv)`. Add a regression test that builds `dist/cli.js` and invokes `status --json` through the component entrypoint.

## Why I Am Confident
The failing test reproduced the exact argv-shape bug before the fix; the same test passes after. Manual tmux QA ran direct `dist/cli.js create-goals` and `dist/cli.js status` with both commands exiting 0.

## Risks
Low. The change only affects known ULW subcommands at the component entrypoint; `hook ...`, `ulw-loop ...`, and unknown-command behavior are preserved.

## User-Visible Behavior Changes
Users and wrapper scripts can invoke `omo ulw-loop status`, `omo ulw-loop create-goals`, and other ULW subcommands without needing a duplicated `ulw-loop` argument.

## Verification
- RED: /tmp/lazycodex-fix-ulw-cli-direct-dispatch-red.log
- GREEN: /tmp/lazycodex-fix-ulw-cli-direct-dispatch-green-targeted.log
- Changed-file Biome, typecheck, build, and full component tests: /tmp/lazycodex-fix-ulw-cli-direct-dispatch-verify.log
- Manual QA tmux transcript: /tmp/lazycodex-fix-ulw-cli-direct-dispatch-tmux-qa.txt

Fixes #42

---
This PR was debugged, implemented, and created with [LazyCodex](https://github.com/code-yeongyu/lazycodex).
Tag: lazycodex-generated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CLI dispatch so `omo ulw-loop <subcommand>` works without repeating `ulw-loop`. Known ULW subcommands like `status` now route directly via the component entrypoint.

- **Bug Fixes**
  - Dispatch known ULW subcommands (`status`, `create-goals`, `complete-goals`, etc.) directly to `ulwLoopCommand(argv)`.
  - Preserve `ulw-loop <subcommand>`, `hook ...`, and unknown-command behavior.
  - Add a regression test that builds `dist/cli.js` and verifies `status --json` is handled as expected.

<sup>Written for commit eb263596124dea587630d25ea287a084b44f2191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

