### PR TITLE
QA: verify PR auto-close guard

### DIFF
--- a/qa-pr-close-guard-check.md
+++ b/qa-pr-close-guard-check.md
@@ -1,0 +1,1 @@
+QA marker file. Safe to delete.


### PR DESCRIPTION
Verifying that the pr-source-guidance workflow closes PRs immediately. Safe to ignore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a QA marker file to trigger the `pr-source-guidance` auto-close guard and confirm PRs get closed immediately. No code impact; file is safe to delete.

<sup>Written for commit bd59cf241070e89f7b3e1b20f60c872f7fae149c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

