### PR TITLE
fix(ulw-plan): accept direct approval replies

### DIFF
--- a/plugins/omo/skills/ulw-plan/SKILL.md
+++ b/plugins/omo/skills/ulw-plan/SKILL.md
@@ -21,7 +21,7 @@ This skill is intentionally compact. The full planning workflow lives in `refere
 
 - **Explore before asking.** Most "questions" are discoverable facts. Ground yourself in the repo with read-only tools and parallel research subagents FIRST; ask the user ONLY what exploration cannot resolve.
 - **Surface, then ask.** After exhausting exploration, present what you found, the genuine remaining ambiguities (with a recommended option for each), and the approach you intend to plan.
-- **Wait for the user's explicit okay before generating the plan.** Never auto-transition from interview to plan generation. No plan file, no Metis gap-analysis, no execution until the user approves the approach.
+- **Wait for the user's explicit okay before generating the plan.** Never auto-transition from interview to plan generation. No plan file, no Metis gap-analysis, no execution until the user approves the approach. Direct replies such as `yes`, `approve`, `proceed`, `write the plan`, or `create the plan` count as approval only when they answer the approval brief.
 - **Planner scope only.** Write only `.omo/plans/<slug>.md` and `.omo/drafts/*.md`. Never edit source. If asked to "just do it", decline: you plan; a worker executes.
 
 ## Interview Discipline (how to ask)

--- a/plugins/omo/skills/ulw-plan/references/full-workflow.md
+++ b/plugins/omo/skills/ulw-plan/references/full-workflow.md
@@ -62,7 +62,7 @@ When exploration is exhausted and the genuine unknowns are answered, do NOT auto
 - the remaining ambiguities, each with the option you recommend,
 - the approach you intend to plan.
 
-Then **wait for the user's explicit okay** before generating the plan. No Metis, no plan file, no execution until the user approves. If the user amends scope, fold it in and re-present the brief. This gate replaces any automatic interview-to-plan transition.
+Then **wait for the user's explicit okay** before generating the plan. No Metis, no plan file, no execution until the user approves. Direct replies such as `yes`, `approve`, `proceed`, `write the plan`, or `create the plan` count as approval only when they answer the approval brief. If the user says `change the scope first` or otherwise amends scope, fold it in and re-present the brief. This gate replaces any automatic interview-to-plan transition.
 
 Narrow `$start-work` bootstrap exception: if `$start-work` invoked this skill because there was no active Boulder work and no selectable plan, the user's `start work` request counts as approval to generate the plan and begin execution. Preserve the normal gate for ordinary `ulw-plan`; ask one focused question only if the objective is missing, destructive, or has a safety/product ambiguity that exploration cannot resolve.
 

--- a/test/ulw-plan-approval-gate.test.mjs
+++ b/test/ulw-plan-approval-gate.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+const skillText = readFileSync("plugins/omo/skills/ulw-plan/SKILL.md", "utf8")
+const workflowText = readFileSync(
+  "plugins/omo/skills/ulw-plan/references/full-workflow.md",
+  "utf8",
+)
+const approvalGateText = `${skillText}\n${workflowText}`
+
+test("approval gate accepts direct approval replies", () => {
+  // Given: a user has just received the approval brief.
+  const directApprovalReplies = ["yes", "approve", "proceed", "write the plan", "create the plan"]
+
+  // When: the bundled workflow documents accepted approval replies.
+  const missingReplies = directApprovalReplies.filter(
+    (reply) => !approvalGateText.toLowerCase().includes(reply),
+  )
+
+  // Then: common direct approvals are documented as sufficient to enter Phase 3.
+  assert.deepEqual(missingReplies, [])
+  assert.match(workflowText, /Phase 3/i)
+})
+
+test("non-approval replies remain gated", () => {
+  // Given: a user reply changes scope instead of approving the current brief.
+  const scopeChangeReply = "change the scope first"
+
+  // When: the bundled workflow documents the non-approval branch.
+  const workflowLower = workflowText.toLowerCase()
+
+  // Then: scope changes are explicitly handled before Phase 3 instead of counted as approval.
+  assert.equal(workflowLower.includes(scopeChangeReply), true)
+  assert.match(workflowText, /fold it in and re-present the brief/i)
+})


### PR DESCRIPTION
Fixes #48

Problem:
- `ulw-plan` required an explicit okay after the approval brief, but the bundled instructions did not name common direct replies such as `proceed`, `write the plan`, or `create the plan`.
- Scope-change replies still need to stay outside the approval path.

Change:
- Document direct approval replies in `SKILL.md` and the full workflow reference.
- Add a regression test for direct approvals and the non-approval scope-change branch.

Evidence:
- RED: `/mnt/c/Users/Han/.omo/evidence/task-2-lazycodex-red.txt`
- GREEN: `/mnt/c/Users/Han/.omo/evidence/task-2-lazycodex-green.txt`
- Non-approval slice: `/mnt/c/Users/Han/.omo/evidence/task-2-lazycodex-non-approval.txt`
- Pack dry-run: `/mnt/c/Users/Han/.omo/evidence/task-2-lazycodex-pack-dry-run.txt`
- Diff check: `/mnt/c/Users/Han/.omo/evidence/task-2-lazycodex-diff-check.txt`
- tmux QA: `/mnt/c/Users/Han/.omo/evidence/task-2-lazycodex.tmux.txt`

Full `npm test` note:
- Current upstream `main` fails `test/no-bunx-text.test.mjs` before this branch's change. Baseline evidence: `/mnt/c/Users/Han/.omo/evidence/task-2-lazycodex-npm-test-baseline.txt`
- This branch shows the same pre-existing failure after the focused approval-gate tests pass: `/mnt/c/Users/Han/.omo/evidence/task-2-lazycodex-npm-test.txt`

Plan: `.omo/plans/quick-fix-pr-waves-20260612.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow direct approval replies for `ulw-plan` so users can respond with "proceed" or "write the plan" to pass the approval gate. Scope-change replies remain gated.

- **Bug Fixes**
  - Document accepted direct approvals in SKILL.md and the full workflow reference.
  - Add regression tests for direct approvals and the non-approval scope-change branch.

<sup>Written for commit e2852a16d8d01dbe1cce7ba0c6670c17432c483c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

