### PR TITLE
fix(lcx-doctor): use ${TMPDIR:-/tmp} and fix obsolete aggregate hook layout check

### DIFF
--- a/plugins/omo/skills/lcx-doctor/SKILL.md
+++ b/plugins/omo/skills/lcx-doctor/SKILL.md
@@ -7,13 +7,13 @@ metadata:
 
 # lcx-doctor
 
-You are a LazyCodex install doctor. Inspect the local installation, compare it against the latest LazyCodex and Codex sources, and return a PASS/WARN/FAIL report where every verdict cites the command output or file that produced it. Diagnose only: the only writes you make are under `/tmp`. Never mutate the user's install, config, or repositories during diagnosis; propose remediations and apply one only when the user explicitly asks afterward.
+You are a LazyCodex install doctor. Inspect the local installation, compare it against the latest LazyCodex and Codex sources, and return a PASS/WARN/FAIL report where every verdict cites the command output or file that produced it. Diagnose only: the only writes you make are under `${TMPDIR:-/tmp}`. Never mutate the user's install, config, or repositories during diagnosis; propose remediations and apply one only when the user explicitly asks afterward.
 
 Use GPT-5.5 style: outcome first, concise, evidence-bound.
 
 ## Required Workflow
 
-1. Materialize the latest sources under `/tmp` first. Every source comparison below reads from these checkouts, never from memory. Re-sync on every run so a cached checkout cannot go stale:
+1. Materialize the latest sources under `${TMPDIR:-/tmp}` first. Every source comparison below reads from these checkouts, never from memory. Re-sync on every run so a cached checkout cannot go stale:
 
 ```bash
 sync_latest_source() {
@@ -26,18 +26,19 @@ sync_latest_source() {
   git -C "$DEST" fetch --depth=1 origin "$DEFAULT_BRANCH"
   git -C "$DEST" checkout -B "$DEFAULT_BRANCH" FETCH_HEAD
 }
-sync_latest_source code-yeongyu/lazycodex /tmp/lazycodex-source
-sync_latest_source openai/codex /tmp/openai-codex-source
+SOURCE_ROOT="${TMPDIR:-/tmp}"
+sync_latest_source code-yeongyu/lazycodex "${SOURCE_ROOT}/lazycodex-source"
+sync_latest_source openai/codex "${SOURCE_ROOT}/openai-codex-source"
 ```
 
 2. Inventory the installed surface. Resolve `CODEX_HOME` (default `~/.codex`), then collect:
    - `codex --version` and how `codex` resolves (`command -v codex`).
    - Installed LazyCodex version: the `version` in the installed plugin manifest, discoverable with `find "${CODEX_HOME:-$HOME/.codex}/plugins" -path '*/.codex-plugin/plugin.json'`. Installed plugins live under `$CODEX_HOME/plugins/cache/<marketplace>/<name>/<version>/`.
-   - Latest LazyCodex version from `/tmp/lazycodex-source` (release tags or the version stamped in the repo) and latest Codex release (`gh release view --repo openai/codex`).
+   - Latest LazyCodex version from `${TMPDIR:-/tmp}/lazycodex-source` (release tags or the version stamped in the repo) and latest Codex release (`gh release view --repo openai/codex`).
    - OS, install method, and `lazycodex` / `lazycodex-ai` bin links resolving (`command -v`).
-3. Check config and wiring against the latest installer, not against assumptions. Read what the current installer under `/tmp/lazycodex-source` writes (installer sources live in the omo-codex package, e.g. `scripts/install/`), then verify the local equivalents:
+3. Check config and wiring against the latest installer, not against assumptions. Read what the current installer under `${TMPDIR:-/tmp}/lazycodex-source` writes (installer sources live in the omo-codex package, e.g. `scripts/install/`), then verify the local equivalents:
    - `$CODEX_HOME/config.toml` exists and parses; LazyCodex-managed entries match what the latest installer would write.
-   - Plugin payload present and non-empty: `hooks/hooks.json`, `skills/`, `.mcp.json`, components under the installed plugin root.
+   - Plugin payload present and non-empty: individual hook JSON files under `hooks/` as enumerated in the `hooks` array of `plugin.json` (the aggregate OMO plugin lists each hook file path directly; an aggregate hooks manifest is not used), `skills/`, `.mcp.json`, components under the installed plugin root.
    - Stale project-local leftovers the installer now removes (e.g. `.codex/hooks.json`, `.codex/skills` in the project) are flagged, not deleted.
 4. Probe the real surface. Do not invoke `lazycodex doctor`; this skill is already running inside that doctor workflow, so calling it would recurse. Instead run non-recursive probes directly: `codex --version`, `command -v codex`, the bin-link checks above, config/plugin payload inspections, and a trivial non-interactive Codex invocation that loads the plugin. Capture stderr verbatim; a clean exit with warnings is WARN, not PASS.
 5. Compare for drift. Where installed bundled files differ from the same files at the installed version, or the latest source renamed or removed something the local config still references, record it with both paths.
@@ -67,7 +68,7 @@ sync_latest_source openai/codex /tmp/openai-codex-source
 | Plugin payload wiring | PASS/WARN/FAIL | [evidence] |
 | Bin links / aliases | PASS/WARN/FAIL | [evidence] |
 | Runtime probe | PASS/WARN/FAIL | [evidence] |
-| Drift vs latest source | PASS/WARN/FAIL | [evidence, citing /tmp/lazycodex-source or /tmp/openai-codex-source paths] |
+| Drift vs latest source | PASS/WARN/FAIL | [evidence, citing ${TMPDIR:-/tmp}/lazycodex-source or ${TMPDIR:-/tmp}/openai-codex-source paths] |
 
 ### Remediations
 1. [Most important fix first: exact command or config edit, and what it resolves.]
@@ -79,7 +80,7 @@ sync_latest_source openai/codex /tmp/openai-codex-source
 ## Follow-up Routing
 
 - Local misconfiguration or stale install: give the remediation; reinstalling via the standard LazyCodex install command is the default fix for payload drift.
-- Defect in LazyCodex or Codex product code: recommend `$lcx-report-bug` to file it, or `$lcx-contribute-bug-fix` when the user wants a fix PR. Both reuse the `/tmp` checkouts you already synced.
+- Defect in LazyCodex or Codex product code: recommend `$lcx-report-bug` to file it, or `$lcx-contribute-bug-fix` when the user wants a fix PR. Both reuse the `${TMPDIR:-/tmp}` checkouts you already synced.
 
 ## Stop Conditions
 
@@ -89,5 +90,5 @@ Do not:
 
 - mutate config, installs, or repositories during diagnosis
 - report a verdict without captured evidence
-- compare against remembered source layout instead of `/tmp/lazycodex-source` and `/tmp/openai-codex-source`
+- compare against remembered source layout instead of `${TMPDIR:-/tmp}/lazycodex-source` and `${TMPDIR:-/tmp}/openai-codex-source`
 - declare healthy while any probe output was never captured

--- a/plugins/omo/test/lcx-bug-skills.test.mjs
+++ b/plugins/omo/test/lcx-bug-skills.test.mjs
@@ -45,7 +45,7 @@ test("#given synced lcx-contribute-bug-fix skill #when inspected #then it delive
 	assert.match(interfaceMetadata, /- "fix bug pr"/);
 });
 
-test("#given synced lcx-doctor skill #when inspected #then it diagnoses installs against latest /tmp sources without mutating them", async () => {
+test("#given synced lcx-doctor skill #when inspected #then it uses TMPDIR for source paths and checks current aggregate hook layout", async () => {
 	// given
 	const skillRoot = join(root, "skills", "lcx-doctor");
 
@@ -55,6 +55,10 @@ test("#given synced lcx-doctor skill #when inspected #then it diagnoses installs
 
 	// then
 	assert.match(skill, /^---\r?\nname: lcx-doctor\r?\n/m);
+	assert.match(skill, /\$\{TMPDIR:-\/tmp\}/);
+	assert.doesNotMatch(skill, /\/tmp\/lazycodex-source/);
+	assert.doesNotMatch(skill, /\/tmp\/openai-codex-source/);
+	assert.doesNotMatch(skill, /hooks\/hooks\.json/);
 	assert.match(interfaceMetadata, /display_name: "\(OmO\) lcx-doctor"/);
 	assert.match(interfaceMetadata, /- "lazycodex doctor"/);
 	assert.match(interfaceMetadata, /- "lazycodex health check"/);


### PR DESCRIPTION
Closes #80

## Bug

`lcx-doctor` had two correctness issues (Problems 1 and 3 from #80):

1. **Hardcoded `/tmp`** — the skill instructed the agent to sync sources to `/tmp/lazycodex-source` and `/tmp/openai-codex-source`. On systems where `/tmp` is restricted or `TMPDIR` points elsewhere this silently breaks source sync.

2. **Obsolete aggregate hook layout check** — Step 3 directed the doctor to verify a `hooks/hooks.json` file under the installed plugin root. The current aggregate OMO plugin manifest (`plugin.json`) enumerates individual hook file paths directly in its `hooks` array; `hooks/hooks.json` is not used (this is explicitly asserted in `test/aggregate-manifest.test.mjs`). Checking for it produces a false negative against a correct installation.

## Fix

- Replace every hardcoded `/tmp` path with `${TMPDIR:-/tmp}` throughout `lcx-doctor/SKILL.md`. Introduce a `SOURCE_ROOT="${TMPDIR:-/tmp}"` variable in the bash sync snippet so it is set once.
- Replace the `hooks/hooks.json` payload check with the correct description: individual hook JSON files under `hooks/` enumerated directly in `plugin.json`'s `hooks` array.

## Verification

Added two new assertions to the existing `lcx-doctor` test block in `plugins/omo/test/lcx-bug-skills.test.mjs`:

```
assert.match(skill, /$\{TMPDIR:-\/tmp\}/);
assert.doesNotMatch(skill, /\/tmp\/lazycodex-source/);
assert.doesNotMatch(skill, /\/tmp\/openai-codex-source/);
assert.doesNotMatch(skill, /hooks\/hooks\.json/);
```

RED before: `node --test test/lcx-bug-skills.test.mjs` → 2 pass / 1 fail
GREEN after: `node --test test/lcx-bug-skills.test.mjs` → 3 pass / 0 fail

Adjacent tests: `node --test test/aggregate-manifest.test.mjs test/aggregate-skills.test.mjs test/aggregate-hooks.test.mjs` → 18 pass / 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two correctness bugs in `lcx-doctor`: it now honors `${TMPDIR:-/tmp}` for source sync and checks the current aggregate hook layout, preventing false negatives and broken runs on systems with restricted `/tmp`.

- **Bug Fixes**
  - Replaced hardcoded `/tmp` paths with `${TMPDIR:-/tmp}`; introduced a `SOURCE_ROOT` variable in the sync snippet.
  - Updated payload check to expect individual hook JSON files under `hooks/` as listed in `plugin.json`; removed the obsolete `hooks/hooks.json` check.
  - Extended tests to assert TMPDIR usage and the correct hook layout (no `hooks/hooks.json`).

<sup>Written for commit 0db60249b35f2e4f7f9403da57b5ff8be5a5e77b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

