### PR TITLE
fix(omo): keep silent subagents alive

### DIFF
--- a/plugins/omo/components/ultrawork/directive.md
+++ b/plugins/omo/components/ultrawork/directive.md
@@ -289,10 +289,16 @@ as inconclusive. Do not generate a plan before spawned research lanes
 that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
-After two silent waits send `TASK STILL ACTIVE: return <deliverable> or
-BLOCKED: <reason>`. After four silent or ack-only checks, close the lane as
-inconclusive, record that it is not approval, and respawn smaller only
-if the deliverable is still required.
+A silent wait is not a child-state transition and must not by itself
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
+`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
+the child has completed without the deliverable, responded ack-only
+after a targeted followup, explicitly reported `BLOCKED:`, or is no
+longer running. If no final status or completion signal exists, treat
+the child as still active and continue independent root work. Close the
+lane as inconclusive and respawn smaller only after one of those
+non-running or non-delivering states is observed and the deliverable is
+still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/plugins/omo/components/ultrawork/test/codex-hook.test.ts
+++ b/plugins/omo/components/ultrawork/test/codex-hook.test.ts
@@ -244,6 +244,25 @@ describe("codex ultrawork hook", () => {
 		expect(directive).toMatch(/WORKING:/);
 	});
 
+	it("#given directive #when wait_agent is silent #then timeout counters never close running children", () => {
+		// given
+		const payload = {
+			hook_event_name: "UserPromptSubmit",
+			prompt: "ulw",
+		};
+
+		// when
+		const output = runUserPromptSubmitHook(payload);
+		const parsed = parseHookOutput(output);
+
+		// then
+		const directive = parsed.hookSpecificOutput.additionalContext;
+		expect(directive).toMatch(/A silent wait is not a child-state transition/);
+		expect(directive).toMatch(/must not by itself\s+trigger `TASK STILL ACTIVE`/);
+		expect(directive).not.toMatch(/After two silent waits/);
+		expect(directive).not.toMatch(/After four silent/);
+	});
+
 	it("#given directive #when inspected #then keeps impact-proportional sizing invariants", () => {
 		// given
 		const payload = {

--- a/plugins/omo/components/ulw-loop/directive.md
+++ b/plugins/omo/components/ulw-loop/directive.md
@@ -289,10 +289,16 @@ as inconclusive. Do not generate a plan before spawned research lanes
 that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
-After two silent waits send `TASK STILL ACTIVE: return <deliverable> or
-BLOCKED: <reason>`. After four silent or ack-only checks, close the lane as
-inconclusive, record that it is not approval, and respawn smaller only
-if the deliverable is still required.
+A silent wait is not a child-state transition and must not by itself
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
+`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
+the child has completed without the deliverable, responded ack-only
+after a targeted followup, explicitly reported `BLOCKED:`, or is no
+longer running. If no final status or completion signal exists, treat
+the child as still active and continue independent root work. Close the
+lane as inconclusive and respawn smaller only after one of those
+non-running or non-delivering states is observed and the deliverable is
+still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 


### PR DESCRIPTION
## Summary

Fixes a Codex/OMO subagent liveness policy contradiction that could cause long-running child agents to be treated as stale when `wait_agent` simply returned no new mailbox update.

## Problem

The `ultrawork` / `ulw-loop` Codex directives already describe `multi_agent_v1.wait_agent` timeouts as mailbox-only signals: a timeout means no new child message arrived, not that the child stopped working.

Later in the same directive, the subagent transition barrier contradicted that by instructing the parent to:

- send `TASK STILL ACTIVE` after two silent waits
- close the lane as inconclusive after four silent or ack-only checks
- respawn a smaller child if the deliverable was still required

That matches the observed failure mode: a child agent can be doing a long read/test/review pass, but the parent sees silent waits and interrupts or replaces it even though it is still running.

## Fix

- Treat silent waits as non-state transitions.
- Do not let a silent `wait_agent` result trigger `TASK STILL ACTIVE`, `close_agent`, or respawn.
- Only send follow-up / close / respawn when there is an actual non-delivering state:
  - child completed without the deliverable
  - child answered ack-only after a targeted follow-up
  - child explicitly reported `BLOCKED:`
  - child is no longer running
- Keep `ulw-loop`'s bundled ultrawork directive synchronized with `ultrawork`.
- Add a regression test so the generated Codex hook output cannot reintroduce the old silent-wait counters.

## Verification

Passing targeted checks:

```text
npm --prefix plugins/omo/components/ultrawork test -- test/codex-hook.test.ts
# 1 file passed, 14 tests passed

npm --prefix plugins/omo/components/ulw-loop test -- test/ultrawork-directive.test.ts
# 1 file passed, 4 tests passed

git diff --cached --check
# passed
```

Broader test notes from this Windows temp clone:

```text
npm --prefix plugins/omo/components/ultrawork test
# 3 files / 25 tests passed
# fails only test/directive-source.test.ts because @oh-my-opencode/prompts-core is not present in this generated LazyCodex checkout

npm --prefix plugins/omo/components/ulw-loop test
# 28 files / 317 tests passed, 5 skipped
# remaining failures are existing Windows environment/path assumptions:
# - spawn npm ENOENT
# - spawn /bin/sh ENOENT
# - POSIX path expectations in test/paths.test.ts
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents long-running subagents from being closed or respawned due to silent `wait_agent` timeouts. Updates `ultrawork` and `ulw-loop` directives and adds a regression test to keep silent subagents alive.

- **Bug Fixes**
  - Treat silent `multi_agent_v1.wait_agent` timeouts as non-transitions; do not trigger `TASK STILL ACTIVE`, `close_agent`, or respawn on silence.
  - Only follow up, close, or respawn when the child finishes without the deliverable, replies ack-only after a targeted follow-up, reports `BLOCKED:`, or stops running.
  - Kept `ulw-loop` in sync with `ultrawork`.
  - Added a regression test to prevent reintroducing silent-wait counters.

<sup>Written for commit 91f72d34db46793d55016486d430f073e5ea985f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

