### PR TITLE
fix(test): make Node tests portable on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test test/*.test.mjs",
+    "test": "node scripts/run-node-test-files.mjs",
     "pack:dry-run": "npm pack --dry-run"
   },
   "keywords": [

--- a/plugins/omo/package.json
+++ b/plugins/omo/package.json
@@ -27,6 +27,6 @@
 		"check": "npm run build && npm test",
 		"sync:hooks": "node scripts/sync-hook-status-messages.mjs",
 		"sync:skills": "node scripts/sync-skills.mjs",
-		"test": "node --test test/*.test.mjs"
+		"test": "node ../../scripts/run-node-test-files.mjs"
 	}
 }

--- a/plugins/omo/test/aggregate-build.test.mjs
+++ b/plugins/omo/test/aggregate-build.test.mjs
@@ -1,9 +1,19 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 
-import { readJson, root } from "./aggregate-plugin-fixture.mjs";
+import { readJson, repoRoot, root } from "./aggregate-plugin-fixture.mjs";
+
+async function pathExists(path) {
+	try {
+		await stat(path);
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
 
 test("#given aggregate plugin build script #when inspected #then generated assets run before workspace builds", async () => {
 	// given
@@ -21,14 +31,19 @@ test("#given aggregate plugin build script #when inspected #then generated asset
 	);
 	assert.match(buildScript, /^node scripts\/sync-version\.mjs &&/);
 	assert.match(buildScript, /materialize-shared-upstreams\.mjs --strict && node scripts\/sync-skills\.mjs/);
-	assert.equal(testScript, "node --test test/*.test.mjs");
+	assert.equal(testScript, "node ../../scripts/run-node-test-files.mjs");
 	assert(packageJson.workspaces.includes("components/ultrawork"));
 	assert.doesNotMatch(packageText, /\bpython3?\b|ultrawork-detector\.py/);
 });
 
-test("#given omo-codex package build script #when inspected #then delegates to the aggregate plugin package", async () => {
+test("#given omo-codex package build script #when inspected #then delegates to the aggregate plugin package", async (t) => {
 	// given
-	const packageJson = JSON.parse(await readFile(join(root, "..", "package.json"), "utf8"));
+	const packageJsonPath = join(repoRoot, "packages", "omo-codex", "package.json");
+	if (!(await pathExists(packageJsonPath))) {
+		t.skip("LazyCodex mirror does not include the omo-codex wrapper package");
+		return;
+	}
+	const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
 
 	// when
 	const buildPluginScript = packageJson.scripts["build:plugin"];

--- a/scripts/run-node-test-files.mjs
+++ b/scripts/run-node-test-files.mjs
@@ -1,0 +1,14 @@
+import { spawnSync } from "node:child_process"
+import { readdirSync } from "node:fs"
+import { join } from "node:path"
+
+const testFiles = readdirSync("test")
+  .filter((file) => file.endsWith(".test.mjs"))
+  .sort()
+  .map((file) => join("test", file))
+
+const result = spawnSync(process.execPath, ["--test", ...testFiles], {
+  stdio: "inherit",
+})
+
+process.exit(result.status ?? 1)

--- a/test/lazycodex-ai-bin.test.mjs
+++ b/test/lazycodex-ai-bin.test.mjs
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict"
 import { existsSync, readFileSync } from "node:fs"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { spawnSync } from "node:child_process"
 import { describe, it } from "node:test"
+import { fileURLToPath } from "node:url"
 
-const root = new URL("..", import.meta.url).pathname
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
 const packageJsonPath = join(root, "package.json")
 const packageLockPath = join(root, "package-lock.json")
 const publishWorkflowPath = join(root, ".github", "workflows", "npm-publish.yml")
@@ -23,6 +24,7 @@ describe("lazycodex-ai npm package", () => {
     assert.equal(manifest.name, "lazycodex-ai")
     assert.equal(manifest.version, releaseVersion)
     assert.equal(manifest.bin?.["lazycodex-ai"], "bin/lazycodex-ai.js")
+    assert.equal(manifest.scripts?.test, "node scripts/run-node-test-files.mjs")
     assert.equal(manifest.private, undefined)
   })
 


### PR DESCRIPTION
## Summary

- replace `node --test test/*.test.mjs` package scripts with a small Node runner that enumerates top-level `.test.mjs` files without relying on shell glob expansion
- resolve the root package test path with `fileURLToPath()` so Windows drive paths are handled correctly
- keep the aggregate plugin build-script test layout-aware when the LazyCodex mirror does not include the `packages/omo-codex` wrapper package

## Verification

- `npm test` from the repository root: 9 pass, 0 fail
- `node --test test\aggregate-build.test.mjs` from `plugins/omo`: 1 pass, 0 fail, 1 skipped
- `git diff --check`

## Note

`npm test` from `plugins/omo` now reaches the full plugin suite on Windows instead of failing before discovery. That broader suite is still red on this checkout with unrelated fixture/artifact failures: 219 pass, 33 fail, 2 skipped. The visible failures include current aggregate MCP path expectations, auto-update marketplace-flow expectations, and missing `@oh-my-opencode/shared-skills` imports.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Node tests portable on Windows by replacing shell globbing with a Node-based runner and fixing Windows path handling in tests. This lets `npm test` run on Windows and keeps aggregate plugin tests robust in mirror layouts.

- **Bug Fixes**
  - Added `scripts/run-node-test-files.mjs` to enumerate `.test.mjs` files and invoke `node --test` without shell globs.
  - Updated `test` scripts in root and `plugins/omo` to use the new runner.
  - Resolved Windows drive paths via `fileURLToPath` in the `lazycodex-ai` bin test.
  - Made the aggregate plugin build-script test layout-aware: skip when `packages/omo-codex` is absent, add a `pathExists` helper, and assert the new `test` script value.

<sup>Written for commit 1d3020751728e845bf9876a1636c379fbd61dd9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

