### PR TITLE
Fix stars pill 404 for logged-out visitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   Project memory, planning, execution, and verified completion inside Codex.</p>
 
   <p>
-    <a href="https://github.com/code-yeongyu/lazycodex/stargazers">
+    <a href="https://github.com/code-yeongyu/lazycodex">
       <img alt="Stars" src="https://img.shields.io/github/stars/code-yeongyu/lazycodex?style=for-the-badge&color=c69ff5&logoColor=D9E0EE&labelColor=302D41" />
     </a>
   </p>

--- a/packages/web/e2e/landing.spec.ts
+++ b/packages/web/e2e/landing.spec.ts
@@ -84,7 +84,7 @@ test.describe("landing page — install + commands", () => {
 })
 
 test.describe("landing page — links + footer", () => {
-  test("github stars pill links to the stargazers url with a count", async ({ page }) => {
+  test("github stars pill links to the github repo with a count", async ({ page }) => {
     await page.goto("/")
     const stars = page.locator(`a[href="${SITE_CONFIG.githubStarsUrl}"]`).first()
     await expect(stars).toBeVisible()

--- a/packages/web/lib/site-config.ts
+++ b/packages/web/lib/site-config.ts
@@ -3,7 +3,9 @@ export const SITE_CONFIG = {
   installCommandAutonomous: "npx lazycodex-ai install --no-tui --codex-autonomous",
   installEquivalent: "npx --yes --package oh-my-openagent omo install --platform=codex",
   githubUrl: "https://github.com/code-yeongyu/lazycodex",
-  githubStarsUrl: "https://github.com/code-yeongyu/lazycodex/stargazers",
+  // GitHub returns 404 on /stargazers for logged-out visitors, so the stars
+  // pill links to the repo page — where the star button lives anyway.
+  githubStarsUrl: "https://github.com/code-yeongyu/lazycodex",
   omoUrl: "https://github.com/code-yeongyu/oh-my-openagent",
   siteUrl: "https://lazycodex.ai",
   docsPath: "/docs",


### PR DESCRIPTION
## Problem

The GitHub stars pill on [lazycodex.ai](https://lazycodex.ai) links to `https://github.com/code-yeongyu/lazycodex/stargazers`. GitHub now returns **404 on `/stargazers` for logged-out visitors** — reproducible even on `facebook/react/stargazers` — so the most prominent CTA on the landing page dead-ends for anonymous visitors. Easy to miss while logged in, since the page works fine for authenticated users.

Verified in a headless browser (logged out):

| URL | Status |
| --- | --- |
| `github.com/code-yeongyu/lazycodex/stargazers` | 404 |
| `github.com/facebook/react/stargazers` | 404 (GitHub-wide policy, not repo-specific) |
| `github.com/code-yeongyu/lazycodex` | 200 |

## Fix

- `packages/web/lib/site-config.ts` — point `githubStarsUrl` at the repo page, where the star button lives anyway.
- `packages/web/e2e/landing.spec.ts` — update the test name to match (assertion logic unchanged; it reads `SITE_CONFIG.githubStarsUrl`).
- `README.md` — the stars badge had the same `/stargazers` link.

## Verification

Ran locally in `packages/web`:

- `pnpm run type-check` — pass
- `pnpm run lint` — pass
- `pnpm run test:e2e` — **59 passed (3.1m)**, including the stars pill link + live API tests and both Lighthouse 100/100/100/100 presets

## Note on the PR routing workflow

I'm aware `pr-source-guidance.yml` auto-closes PRs here and points to `oh-my-openagent/packages/omo-codex` — but `packages/web` (the lazycodex.ai source) only exists in this repository, and the sync script in oh-my-openagent copies only the marketplace/plugin and the workflow file. Website fixes currently have no valid upstream PR path, so opening here; happy to re-file wherever you prefer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point the landing page stars pill to the repo page instead of /stargazers to avoid GitHub’s 404 for logged-out visitors. Also updates the README badge and the e2e test to match.

- Bug Fixes
  - packages/web/lib/site-config.ts: set githubStarsUrl to https://github.com/code-yeongyu/lazycodex
  - packages/web/e2e/landing.spec.ts: rename test to reflect new target; assertions unchanged
  - README.md: update stars badge link to the repo page

<sup>Written for commit b7bb6d19d3efa8c810eaa8749f927b7f957d074a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

