### PR TITLE
fix(readme): point stars badge at repo page not /stargazers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   Project memory, planning, execution, and verified completion inside Codex.</p>
 
   <p>
-    <a href="https://github.com/code-yeongyu/lazycodex/stargazers">
+    <a href="https://github.com/code-yeongyu/lazycodex">
       <img alt="Stars" src="https://img.shields.io/github/stars/code-yeongyu/lazycodex?style=for-the-badge&color=c69ff5&logoColor=D9E0EE&labelColor=302D41" />
     </a>
   </p>


### PR DESCRIPTION
## Summary
Fix the remaining `/stargazers` link so the stars badge/pill no longer 404s for logged-out visitors (GitHub restricted `/stargazers` to repo admins in July 2026).

The landing-page pill component and its e2e test already handle this (they assert no `/stargazers` deep links). This fixes the one remaining reference: the README stars badge now links to the repo page (`/code-yeongyu/lazycodex`), where the star button lives anyway.

Reported by @devswha in #122 (verified fix originally in #121, which was auto-closed by `pr-source-guidance.yml`). Fixed by [sisyphus-bot].

Closes #122.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README stars badge to link to the repo page instead of /stargazers, avoiding 404s for logged-out visitors after GitHub’s change. Matches the landing-page pill behavior.

<sup>Written for commit 3fdad1e8104bc91a592f7f2ef2250291f3876d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

