### PR TITLE
fix(omo): prevent duplicate Orca-mirrored agent roles

### DIFF
--- a/plugins/omo/components/bootstrap/dist/cli.js
+++ b/plugins/omo/components/bootstrap/dist/cli.js
@@ -3543,10 +3543,14 @@ async function linkBundledAgentsStep(options) {
   const agentsTarget = join21(options.codexHome, "agents");
   try {
     const stageRoot = join21(options.pluginData, "bootstrap", "agents-stage");
+    const previouslyInstalledAgents = await readInstalledAgentPaths(stageRoot);
     const existingConfig = await readConfigIfPresent(join21(options.codexHome, "config.toml"));
     const foreignAgentFiles = await stageBundledAgents(options.pluginRoot, stageRoot, existingConfig);
-    for (const agentFile of foreignAgentFiles)
-      await rm10(join21(agentsTarget, agentFile), { force: true });
+    for (const agentFile of foreignAgentFiles) {
+      const agentPath = join21(agentsTarget, agentFile);
+      if (previouslyInstalledAgents.has(agentPath))
+        await rm10(agentPath, { force: true });
+    }
     const preservedReasoning = await capturePreservedAgentReasoning({ codexHome: options.codexHome });
     const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome: options.codexHome });
     const linked = await linkCachedPluginAgents({
@@ -3568,6 +3572,18 @@ async function linkBundledAgentsStep(options) {
         }
       ]
     };
+  }
+}
+async function readInstalledAgentPaths(stageRoot) {
+  try {
+    const parsed = JSON.parse(await readFile(join21(stageRoot, ".installed-agents.json"), "utf8"));
+    if (!isRecord(parsed) || !Array.isArray(parsed["agents"]))
+      return new Set();
+    return new Set(parsed["agents"].filter((path) => typeof path === "string"));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT")
+      return new Set();
+    throw error;
   }
 }
 async function stageBundledAgents(pluginRoot, stageRoot, existingConfig) {

--- a/plugins/omo/components/bootstrap/dist/cli.js
+++ b/plugins/omo/components/bootstrap/dist/cli.js
@@ -3544,11 +3544,12 @@ async function linkBundledAgentsStep(options) {
   try {
     const stageRoot = join21(options.pluginData, "bootstrap", "agents-stage");
     const previouslyInstalledAgents = await readInstalledAgentPaths(stageRoot);
+    const previouslyStagedAgentContents = await readStagedAgentContents(stageRoot);
     const existingConfig = await readConfigIfPresent(join21(options.codexHome, "config.toml"));
     const foreignAgentFiles = await stageBundledAgents(options.pluginRoot, stageRoot, existingConfig);
     for (const agentFile of foreignAgentFiles) {
       const agentPath = join21(agentsTarget, agentFile);
-      if (previouslyInstalledAgents.has(agentPath))
+      if (previouslyInstalledAgents.has(agentPath) && await matchesAgentContent(agentPath, previouslyStagedAgentContents.get(agentFile)))
         await rm10(agentPath, { force: true });
     }
     const preservedReasoning = await capturePreservedAgentReasoning({ codexHome: options.codexHome });
@@ -3583,6 +3584,27 @@ async function readInstalledAgentPaths(stageRoot) {
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT")
       return new Set();
+    throw error;
+  }
+}
+async function readStagedAgentContents(stageRoot) {
+  const contents = new Map();
+  const componentsRoot = join21(stageRoot, "components");
+  for (const componentName of await directoryNames(componentsRoot)) {
+    const agentsDir = join21(componentsRoot, componentName, "agents");
+    for (const agentFile of await fileNames(agentsDir))
+      contents.set(agentFile, await readFile(join21(agentsDir, agentFile), "utf8"));
+  }
+  return contents;
+}
+async function matchesAgentContent(path, expectedContent) {
+  if (expectedContent === void 0)
+    return false;
+  try {
+    return await readFile(path, "utf8") === expectedContent;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT")
+      return false;
     throw error;
   }
 }

--- a/plugins/omo/components/bootstrap/dist/cli.js
+++ b/plugins/omo/components/bootstrap/dist/cli.js
@@ -3543,7 +3543,10 @@ async function linkBundledAgentsStep(options) {
   const agentsTarget = join21(options.codexHome, "agents");
   try {
     const stageRoot = join21(options.pluginData, "bootstrap", "agents-stage");
-    await stageBundledAgents(options.pluginRoot, stageRoot);
+    const existingConfig = await readConfigIfPresent(join21(options.codexHome, "config.toml"));
+    const foreignAgentFiles = await stageBundledAgents(options.pluginRoot, stageRoot, existingConfig);
+    for (const agentFile of foreignAgentFiles)
+      await rm10(join21(agentsTarget, agentFile), { force: true });
     const preservedReasoning = await capturePreservedAgentReasoning({ codexHome: options.codexHome });
     const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome: options.codexHome });
     const linked = await linkCachedPluginAgents({
@@ -3567,9 +3570,10 @@ async function linkBundledAgentsStep(options) {
     };
   }
 }
-async function stageBundledAgents(pluginRoot, stageRoot) {
+async function stageBundledAgents(pluginRoot, stageRoot, existingConfig) {
   await rm10(stageRoot, { force: true, recursive: true });
   await mkdir7(stageRoot, { recursive: true });
+  const foreignAgentFiles = [];
   const componentsRoot = join21(pluginRoot, "components");
   for (const componentName of await directoryNames(componentsRoot)) {
     const agentsDir = join21(componentsRoot, componentName, "agents");
@@ -3579,9 +3583,15 @@ async function stageBundledAgents(pluginRoot, stageRoot) {
     const stagedAgentsDir = join21(stageRoot, "components", componentName, "agents");
     await mkdir7(stagedAgentsDir, { recursive: true });
     for (const agentFile of agentFiles) {
+      const agentConfig = { configFile: `./agents/${agentFile}`, name: agentNameFromToml3(agentFile) };
+      if (hasForeignAgentRegistration(existingConfig, agentConfig)) {
+        foreignAgentFiles.push(agentFile);
+        continue;
+      }
       await copyFile2(join21(agentsDir, agentFile), join21(stagedAgentsDir, agentFile));
     }
   }
+  return foreignAgentFiles;
 }
 async function updateConfigStep(options, inputs, degraded) {
   const configPath = join21(options.codexHome, "config.toml");

--- a/plugins/omo/components/bootstrap/src/agent-staging.ts
+++ b/plugins/omo/components/bootstrap/src/agent-staging.ts
@@ -1,7 +1,20 @@
-import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
+import { copyFile, mkdir, readFile, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 
 import { hasForeignAgentRegistration } from "../../../../src/install/codex-config-agents.ts";
+
+const AGENT_MANIFEST = ".installed-agents.json";
+
+export async function readInstalledAgentPaths(stageRoot: string): Promise<ReadonlySet<string>> {
+	try {
+		const parsed: unknown = JSON.parse(await readFile(join(stageRoot, AGENT_MANIFEST), "utf8"));
+		if (!isRecord(parsed) || !Array.isArray(parsed["agents"])) return new Set();
+		return new Set(parsed["agents"].filter((path): path is string => typeof path === "string"));
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return new Set();
+		throw error;
+	}
+}
 
 export async function stageBundledAgents(
 	pluginRoot: string,
@@ -44,7 +57,9 @@ async function fileNames(root: string): Promise<string[]> {
 
 async function entryNames(root: string, keep: (entry: { isDirectory(): boolean; isFile(): boolean }) => boolean): Promise<string[]> {
 	try {
-		const entries = await readdir(root, { withFileTypes: true });
+		const entries: readonly { isDirectory(): boolean; isFile(): boolean; name: string }[] = await readdir(root, {
+			withFileTypes: true,
+		});
 		return entries
 			.filter((entry) => keep(entry))
 			.map((entry) => entry.name)
@@ -53,4 +68,8 @@ async function entryNames(root: string, keep: (entry: { isDirectory(): boolean; 
 		if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
 		throw error;
 	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/plugins/omo/components/bootstrap/src/agent-staging.ts
+++ b/plugins/omo/components/bootstrap/src/agent-staging.ts
@@ -16,6 +16,28 @@ export async function readInstalledAgentPaths(stageRoot: string): Promise<Readon
 	}
 }
 
+export async function readStagedAgentContents(stageRoot: string): Promise<ReadonlyMap<string, string>> {
+	const contents = new Map<string, string>();
+	const componentsRoot = join(stageRoot, "components");
+	for (const componentName of await directoryNames(componentsRoot)) {
+		const agentsDir = join(componentsRoot, componentName, "agents");
+		for (const agentFile of await fileNames(agentsDir)) {
+			contents.set(agentFile, await readFile(join(agentsDir, agentFile), "utf8"));
+		}
+	}
+	return contents;
+}
+
+export async function matchesAgentContent(path: string, expectedContent: string | undefined): Promise<boolean> {
+	if (expectedContent === undefined) return false;
+	try {
+		return (await readFile(path, "utf8")) === expectedContent;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
 export async function stageBundledAgents(
 	pluginRoot: string,
 	stageRoot: string,

--- a/plugins/omo/components/bootstrap/src/agent-staging.ts
+++ b/plugins/omo/components/bootstrap/src/agent-staging.ts
@@ -1,0 +1,56 @@
+import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { hasForeignAgentRegistration } from "../../../../src/install/codex-config-agents.ts";
+
+export async function stageBundledAgents(
+	pluginRoot: string,
+	stageRoot: string,
+	existingConfig: string,
+): Promise<readonly string[]> {
+	await rm(stageRoot, { force: true, recursive: true });
+	await mkdir(stageRoot, { recursive: true });
+	const foreignAgentFiles: string[] = [];
+	const componentsRoot = join(pluginRoot, "components");
+	for (const componentName of await directoryNames(componentsRoot)) {
+		const agentsDir = join(componentsRoot, componentName, "agents");
+		const agentFiles = (await fileNames(agentsDir)).filter((name) => name.endsWith(".toml"));
+		if (agentFiles.length === 0) continue;
+		const stagedAgentsDir = join(stageRoot, "components", componentName, "agents");
+		await mkdir(stagedAgentsDir, { recursive: true });
+		for (const agentFile of agentFiles) {
+			const agentConfig = { configFile: `./agents/${agentFile}`, name: agentNameFromToml(agentFile) };
+			if (hasForeignAgentRegistration(existingConfig, agentConfig)) {
+				foreignAgentFiles.push(agentFile);
+				continue;
+			}
+			await copyFile(join(agentsDir, agentFile), join(stagedAgentsDir, agentFile));
+		}
+	}
+	return foreignAgentFiles;
+}
+
+export function agentNameFromToml(fileName: string): string {
+	return fileName.endsWith(".toml") ? fileName.slice(0, -".toml".length) : fileName;
+}
+
+async function directoryNames(root: string): Promise<string[]> {
+	return entryNames(root, (entry) => entry.isDirectory());
+}
+
+async function fileNames(root: string): Promise<string[]> {
+	return entryNames(root, (entry) => entry.isFile());
+}
+
+async function entryNames(root: string, keep: (entry: { isDirectory(): boolean; isFile(): boolean }) => boolean): Promise<string[]> {
+	try {
+		const entries = await readdir(root, { withFileTypes: true });
+		return entries
+			.filter((entry) => keep(entry))
+			.map((entry) => entry.name)
+			.sort();
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+		throw error;
+	}
+}

--- a/plugins/omo/components/bootstrap/src/setup.ts
+++ b/plugins/omo/components/bootstrap/src/setup.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
+import { readFile, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 // These relative imports resolve at BUILD time in the monorepo; esbuild
@@ -17,6 +17,7 @@ import { trustedHookStatesForPlugin } from "../../../../src/install/codex-hook-t
 import { resolveCodexInstallerBinDir } from "../../../../src/install/codex-installer-bin-dir.ts";
 import { prepareGitBashForInstall } from "../../../../src/install/git-bash.ts";
 import type { CodexAgentConfig, GitBashResolution } from "../../../../src/install/types.ts";
+import { agentNameFromToml, stageBundledAgents } from "./agent-staging.ts";
 import { appendBootstrapLog, BOOTSTRAP_DOCTOR_HINT } from "./worker.ts";
 import type { BootstrapDegradedEntry, BootstrapStepOutcome } from "./worker.ts";
 
@@ -91,7 +92,9 @@ async function linkBundledAgentsStep(options: WorkerSetupOptions): Promise<Agent
 		// first: bootstrap must never persist anything under PLUGIN_ROOT (the
 		// Codex-managed marketplace cache).
 		const stageRoot = join(options.pluginData, "bootstrap", "agents-stage");
-		await stageBundledAgents(options.pluginRoot, stageRoot);
+		const existingConfig = await readConfigIfPresent(join(options.codexHome, "config.toml"));
+		const foreignAgentFiles = await stageBundledAgents(options.pluginRoot, stageRoot, existingConfig);
+		for (const agentFile of foreignAgentFiles) await rm(join(agentsTarget, agentFile), { force: true });
 		const preservedReasoning = await capturePreservedAgentReasoning({ codexHome: options.codexHome });
 		const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome: options.codexHome });
 		const linked = await linkCachedPluginAgents({
@@ -118,22 +121,6 @@ async function linkBundledAgentsStep(options: WorkerSetupOptions): Promise<Agent
 	}
 }
 
-async function stageBundledAgents(pluginRoot: string, stageRoot: string): Promise<void> {
-	await rm(stageRoot, { force: true, recursive: true });
-	await mkdir(stageRoot, { recursive: true });
-	const componentsRoot = join(pluginRoot, "components");
-	for (const componentName of await directoryNames(componentsRoot)) {
-		const agentsDir = join(componentsRoot, componentName, "agents");
-		const agentFiles = (await fileNames(agentsDir)).filter((name) => name.endsWith(".toml"));
-		if (agentFiles.length === 0) continue;
-		const stagedAgentsDir = join(stageRoot, "components", componentName, "agents");
-		await mkdir(stagedAgentsDir, { recursive: true });
-		for (const agentFile of agentFiles) {
-			await copyFile(join(agentsDir, agentFile), join(stagedAgentsDir, agentFile));
-		}
-	}
-}
-
 async function updateConfigStep(
 	options: WorkerSetupOptions,
 	inputs: { agentConfigs: readonly CodexAgentConfig[]; gitBashEnabled: boolean },
@@ -147,7 +134,7 @@ async function updateConfigStep(
 		// for such a role would collide with the mirrored entry once Codex
 		// discovers <codexHome>/agents/<name>.toml (two different file paths for
 		// one role name -> upstream warning), so foreign pre-existing blocks are
-		// left untouched; directory discovery still loads the linked toml.
+		// left untouched and their runtime-local copies are excluded from staging.
 		const existingConfig = await readConfigIfPresent(configPath);
 		const agentConfigs = inputs.agentConfigs.filter(
 			(agentConfig) => !hasForeignAgentRegistration(existingConfig, agentConfig),
@@ -266,31 +253,6 @@ async function stampGitBashEnvStep(options: WorkerSetupOptions, degraded: Bootst
 			reason: `failed to stamp ${join(options.pluginRoot, ".mcp.json")}: ${errorMessage(error)}`,
 		});
 	}
-}
-
-async function directoryNames(root: string): Promise<string[]> {
-	return entryNames(root, (entry) => entry.isDirectory());
-}
-
-async function fileNames(root: string): Promise<string[]> {
-	return entryNames(root, (entry) => entry.isFile());
-}
-
-async function entryNames(root: string, keep: (entry: { isDirectory(): boolean; isFile(): boolean }) => boolean): Promise<string[]> {
-	try {
-		const entries = await readdir(root, { withFileTypes: true });
-		return entries
-			.filter((entry) => keep(entry))
-			.map((entry) => entry.name)
-			.sort();
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
-		throw error;
-	}
-}
-
-function agentNameFromToml(fileName: string): string {
-	return fileName.endsWith(".toml") ? fileName.slice(0, -".toml".length) : fileName;
 }
 
 function errorMessage(error: unknown): string {

--- a/plugins/omo/components/bootstrap/src/setup.ts
+++ b/plugins/omo/components/bootstrap/src/setup.ts
@@ -17,7 +17,7 @@ import { trustedHookStatesForPlugin } from "../../../../src/install/codex-hook-t
 import { resolveCodexInstallerBinDir } from "../../../../src/install/codex-installer-bin-dir.ts";
 import { prepareGitBashForInstall } from "../../../../src/install/git-bash.ts";
 import type { CodexAgentConfig, GitBashResolution } from "../../../../src/install/types.ts";
-import { agentNameFromToml, stageBundledAgents } from "./agent-staging.ts";
+import { agentNameFromToml, readInstalledAgentPaths, stageBundledAgents } from "./agent-staging.ts";
 import { appendBootstrapLog, BOOTSTRAP_DOCTOR_HINT } from "./worker.ts";
 import type { BootstrapDegradedEntry, BootstrapStepOutcome } from "./worker.ts";
 
@@ -92,9 +92,13 @@ async function linkBundledAgentsStep(options: WorkerSetupOptions): Promise<Agent
 		// first: bootstrap must never persist anything under PLUGIN_ROOT (the
 		// Codex-managed marketplace cache).
 		const stageRoot = join(options.pluginData, "bootstrap", "agents-stage");
+		const previouslyInstalledAgents = await readInstalledAgentPaths(stageRoot);
 		const existingConfig = await readConfigIfPresent(join(options.codexHome, "config.toml"));
 		const foreignAgentFiles = await stageBundledAgents(options.pluginRoot, stageRoot, existingConfig);
-		for (const agentFile of foreignAgentFiles) await rm(join(agentsTarget, agentFile), { force: true });
+		for (const agentFile of foreignAgentFiles) {
+			const agentPath = join(agentsTarget, agentFile);
+			if (previouslyInstalledAgents.has(agentPath)) await rm(agentPath, { force: true });
+		}
 		const preservedReasoning = await capturePreservedAgentReasoning({ codexHome: options.codexHome });
 		const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome: options.codexHome });
 		const linked = await linkCachedPluginAgents({

--- a/plugins/omo/components/bootstrap/src/setup.ts
+++ b/plugins/omo/components/bootstrap/src/setup.ts
@@ -17,7 +17,13 @@ import { trustedHookStatesForPlugin } from "../../../../src/install/codex-hook-t
 import { resolveCodexInstallerBinDir } from "../../../../src/install/codex-installer-bin-dir.ts";
 import { prepareGitBashForInstall } from "../../../../src/install/git-bash.ts";
 import type { CodexAgentConfig, GitBashResolution } from "../../../../src/install/types.ts";
-import { agentNameFromToml, readInstalledAgentPaths, stageBundledAgents } from "./agent-staging.ts";
+import {
+	agentNameFromToml,
+	matchesAgentContent,
+	readInstalledAgentPaths,
+	readStagedAgentContents,
+	stageBundledAgents,
+} from "./agent-staging.ts";
 import { appendBootstrapLog, BOOTSTRAP_DOCTOR_HINT } from "./worker.ts";
 import type { BootstrapDegradedEntry, BootstrapStepOutcome } from "./worker.ts";
 
@@ -93,11 +99,17 @@ async function linkBundledAgentsStep(options: WorkerSetupOptions): Promise<Agent
 		// Codex-managed marketplace cache).
 		const stageRoot = join(options.pluginData, "bootstrap", "agents-stage");
 		const previouslyInstalledAgents = await readInstalledAgentPaths(stageRoot);
+		const previouslyStagedAgentContents = await readStagedAgentContents(stageRoot);
 		const existingConfig = await readConfigIfPresent(join(options.codexHome, "config.toml"));
 		const foreignAgentFiles = await stageBundledAgents(options.pluginRoot, stageRoot, existingConfig);
 		for (const agentFile of foreignAgentFiles) {
 			const agentPath = join(agentsTarget, agentFile);
-			if (previouslyInstalledAgents.has(agentPath)) await rm(agentPath, { force: true });
+			if (
+				previouslyInstalledAgents.has(agentPath) &&
+				(await matchesAgentContent(agentPath, previouslyStagedAgentContents.get(agentFile)))
+			) {
+				await rm(agentPath, { force: true });
+			}
 		}
 		const preservedReasoning = await capturePreservedAgentReasoning({ codexHome: options.codexHome });
 		const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome: options.codexHome });

--- a/plugins/omo/test/bootstrap-setup.test.mjs
+++ b/plugins/omo/test/bootstrap-setup.test.mjs
@@ -176,6 +176,7 @@ test("#given a config.toml with no pre-existing agent entries #when the worker s
 test("#given an unmanaged local role with the same name as an Orca registration #when the worker setup runs #then the local role is preserved", async () => {
 	await withSetupFixture(async (fixture) => {
 		const userAgent = 'description = "User-owned explorer"\nmodel = "gpt-5.6"\n';
+		await runWorkerSetup(setupOptions(fixture));
 		await mkdir(join(fixture.codexHome, "agents"), { recursive: true });
 		await writeFile(join(fixture.codexHome, "agents", "explorer.toml"), userAgent);
 		await writeFile(

--- a/plugins/omo/test/bootstrap-setup.test.mjs
+++ b/plugins/omo/test/bootstrap-setup.test.mjs
@@ -130,6 +130,7 @@ test("#given a completed first run #when the worker setup runs again #then confi
 test("#given a config.toml that already declares [agents.explorer] at a different path (Orca mirror) #when the worker setup runs #then the mirrored role is not also linked into the runtime agents directory", async () => {
 	await withSetupFixture(async (fixture) => {
 		const orcaMirrorPath = "/orca-mirrored-home/.codex/agents/explorer.toml";
+		await runWorkerSetup(setupOptions(fixture));
 		await writeFile(
 			join(fixture.codexHome, "config.toml"),
 			`[marketplaces.sisyphuslabs]\n${MARKETPLACE_SOURCE_LINE}\n\n[agents.explorer]\nconfig_file = "${orcaMirrorPath}"\n`,
@@ -169,6 +170,22 @@ test("#given a config.toml with no pre-existing agent entries #when the worker s
 		const config = await readConfig(fixture);
 		assert.match(config, /\[agents\.explorer\]\nconfig_file = "\.\/agents\/explorer\.toml"/);
 		assert.match(config, /\[agents\.metis\]\nconfig_file = "\.\/agents\/metis\.toml"/);
+	});
+});
+
+test("#given an unmanaged local role with the same name as an Orca registration #when the worker setup runs #then the local role is preserved", async () => {
+	await withSetupFixture(async (fixture) => {
+		const userAgent = 'description = "User-owned explorer"\nmodel = "gpt-5.6"\n';
+		await mkdir(join(fixture.codexHome, "agents"), { recursive: true });
+		await writeFile(join(fixture.codexHome, "agents", "explorer.toml"), userAgent);
+		await writeFile(
+			join(fixture.codexHome, "config.toml"),
+			`[marketplaces.sisyphuslabs]\n${MARKETPLACE_SOURCE_LINE}\n\n[agents.explorer]\nconfig_file = "/orca-mirrored-home/.codex/agents/explorer.toml"\n`,
+		);
+
+		await runWorkerSetup(setupOptions(fixture));
+
+		assert.equal(await readFile(join(fixture.codexHome, "agents", "explorer.toml"), "utf8"), userAgent);
 	});
 });
 

--- a/plugins/omo/test/bootstrap-setup.test.mjs
+++ b/plugins/omo/test/bootstrap-setup.test.mjs
@@ -127,7 +127,7 @@ test("#given a completed first run #when the worker setup runs again #then confi
 	});
 });
 
-test("#given a config.toml that already declares [agents.explorer] at a different path (Orca mirror) #when the worker setup runs #then no second colliding registration is added for that role", async () => {
+test("#given a config.toml that already declares [agents.explorer] at a different path (Orca mirror) #when the worker setup runs #then the mirrored role is not also linked into the runtime agents directory", async () => {
 	await withSetupFixture(async (fixture) => {
 		const orcaMirrorPath = "/orca-mirrored-home/.codex/agents/explorer.toml";
 		await writeFile(
@@ -149,11 +149,15 @@ test("#given a config.toml that already declares [agents.explorer] at a differen
 			"no colliding ./agents registration for the mirrored role",
 		);
 		assert.match(config, /\[agents\.metis\]\nconfig_file = "\.\/agents\/metis\.toml"/);
-		assert.equal(
-			await readFile(join(fixture.codexHome, "agents", "explorer.toml"), "utf8"),
-			BUNDLED_EXPLORER_TOML,
-			"the linked toml is still staged for Codex directory discovery",
+		await assert.rejects(() => stat(join(fixture.codexHome, "agents", "explorer.toml")), { code: "ENOENT" });
+		assert.equal(await readFile(join(fixture.codexHome, "agents", "metis.toml"), "utf8"), BUNDLED_METIS_TOML);
+		const manifest = JSON.parse(
+			await readFile(join(fixture.pluginData, "bootstrap", "agents-stage", ".installed-agents.json"), "utf8"),
 		);
+		assert.deepEqual(manifest.agents, [join(fixture.codexHome, "agents", "metis.toml")]);
+		await runWorkerSetup(setupOptions(fixture));
+		assert.equal(await readConfig(fixture), config);
+		await assert.rejects(() => stat(join(fixture.codexHome, "agents", "explorer.toml")), { code: "ENOENT" });
 	});
 });
 


### PR DESCRIPTION
## Summary

- skip materializing bundled agent TOMLs when Orca already registers the role from a foreign runtime path
- remove only previously LazyCodex-managed local copies whose contents still match the previous staged TOML
- preserve user-owned or user-modified same-name agent files
- keep the shipped `dist/cli.js` behavior in sync with the TypeScript source

## Root cause

Orca mirrors `[agents.<name>]` entries into its runtime `CODEX_HOME/config.toml`, pointing at another runtime's agent file. LazyCodex's bootstrap filtered the config update but still copied the same bundled TOML into the active `CODEX_HOME/agents/` directory. Codex then auto-discovered both paths and reported duplicate agent roles.

## Validation

- `node --test plugins/omo/test/bootstrap-*.test.mjs`: 51 passed
- `node --check plugins/omo/components/bootstrap/dist/cli.js`: passed
- shipped CLI QA: managed copy removed; replaced user file preserved; unmanaged user file preserved
- `node components/bootstrap/scripts/build.mjs`: exit 0; this sparse checkout emits pre-existing unresolved sibling-import warnings and retains the existing bundled dist

Fixes #150
Related: #149

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate agent roles when Orca mirrors agents into `config.toml`. We now skip staging mirrored roles, remove only previously managed copies, and preserve user files.

- **Bug Fixes**
  - Skip staging bundled `*.toml` when `config.toml` already points to a foreign runtime path.
  - Remove only LazyCodex-managed copies that still match previously staged content; leave user-owned or modified files.
  - Track installed agents via `.installed-agents.json` to safely prune only managed duplicates.
  - Keep `plugins/omo/components/bootstrap/dist/cli.js` in sync with the TypeScript source and add tests for idempotent runs and user-file preservation.

<sup>Written for commit 5651d0e323ade49a83ad51f929ef6248996c8eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/lazycodex/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

